### PR TITLE
Provide forward ref prop to gain access to editor domnode

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Editable area component, acts as wrapper around Slate.
 | className | string |  |
 | readOnly | boolean | Optional, defaults to false |
 | children | React.ReactNode \| undefined  |  |
+| ref | React.LegacyRef<HTMLDivElement> | Provides reference to Slate Editable dom node |
 
 ### Provides GutterContext (_used internally_)
 

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -2,7 +2,8 @@ import {
   type PropsWithChildren,
   useMemo,
   useCallback,
-  useEffect
+  useEffect,
+  forwardRef
 } from 'react'
 import { createEditor, Editor as SlateEditor, type Descendant, Editor, type NodeEntry, Node, Text, Range } from 'slate'
 import { withHistory } from 'slate-history'
@@ -44,7 +45,7 @@ export interface TextbitEditableProps extends PropsWithChildren {
   readOnly?: boolean
 }
 
-export const TextbitEditable = ({
+export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(function TextbitEditable({
   children,
   value,
   onChange,
@@ -53,7 +54,7 @@ export const TextbitEditable = ({
   dir = 'ltr',
   className = '',
   readOnly = false
-}: TextbitEditableProps) => {
+}: TextbitEditableProps, ref: React.LegacyRef<HTMLDivElement>) {
   const { plugins, components, actions } = usePluginRegistry()
   const { autoFocus, onBlur, onFocus, placeholders } = useTextbit()
   const { dispatch, debounce: debounceTimeout, spellcheckDebounce: spellcheckDebounceTimeout } = useTextbit()
@@ -112,6 +113,7 @@ export const TextbitEditable = ({
           <Gutter.Content>
             <PresenceOverlay isCollaborative={!!yjsEditor}>
               <SlateEditable
+                ref={ref}
                 readOnly={readOnly}
                 className={className}
                 autoFocus={autoFocus}
@@ -136,7 +138,7 @@ export const TextbitEditable = ({
       </SlateSlate>
     </DragStateProvider>
   )
-}
+})
 
 
 /**

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, forwardRef } from 'react'
 import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry } from 'slate'
 import { Editable, ReactEditor, type RenderElementProps, type RenderLeafProps, useFocused } from 'slate-react'
 import { toggleLeaf } from '../../../../lib/toggleLeaf'
@@ -7,7 +7,7 @@ import { useTextbit } from '../../../../components/TextbitRoot'
 import { TextbitEditor } from '../../../../lib'
 import { useContextMenu } from '../../../../hooks/useContextMenu'
 
-export const SlateEditable = ({ className = '', renderSlateElement, renderLeafComponent, textbitEditor, actions, autoFocus, onBlur, onFocus, onDecorate, readOnly }: {
+interface SlateEditableProps {
   className?: string
   renderSlateElement: (props: RenderElementProps) => JSX.Element
   renderLeafComponent: (props: RenderLeafProps) => JSX.Element
@@ -18,16 +18,30 @@ export const SlateEditable = ({ className = '', renderSlateElement, renderLeafCo
   onFocus?: React.FocusEventHandler<HTMLDivElement>
   onDecorate?: ((entry: NodeEntry) => Range[]) | undefined
   readOnly?: boolean
-}): JSX.Element => {
+}
+
+export const SlateEditable = forwardRef(function SlateEditable({
+  className = '',
+  renderSlateElement,
+  renderLeafComponent,
+  textbitEditor,
+  actions,
+  autoFocus,
+  onBlur,
+  onFocus,
+  onDecorate,
+  readOnly
+}: SlateEditableProps, ref: React.LegacyRef<HTMLDivElement>): JSX.Element {
   const focused = useFocused()
   const { placeholder } = useTextbit()
-  const ref = useRef<HTMLDivElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
 
-  useContextMenu(ref)
+  useContextMenu(wrapperRef)
 
   return (
-    <div ref={ref}>
+    <div ref={wrapperRef}>
       <Editable
+        ref={ref}
         placeholder={placeholder}
         readOnly={readOnly}
         data-state={focused ? 'focused' : ''}
@@ -57,10 +71,11 @@ export const SlateEditable = ({ className = '', renderSlateElement, renderLeafCo
             onFocus(event)
           }
         }}
-      />
+      >
+      </Editable>
     </div>
   )
-}
+})
 
 
 /**


### PR DESCRIPTION
Added forward ref prop to provide access to slate editor dom node which can be useful when externally controlling focus etc.