### PR TITLE
Feature/ele 1145 textbit must be able to receive lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Editable area component, acts as wrapper around Slate.
 | onChange | (Descendant[] => void) | Function to receive all changes |
 | onSpellcheck | onSpellcheck?: (texts: string[]) => Array<Array<{<br> str: string,<br> pos: number,<br> sub: string[]<br> }>> | Optional, callback function to handle spellchecking of strings |
 | dir | "ltr" \| "rtl" | Optional, defaults to _ltr_ |
+| lang | string | Optional langage (e.g en, en-BR, sv, sv_FI). Falls back to html document language, then browser language and last "en".
 | yjsEditor | BaseEditor | BaseEditor created with `withYjs()` and `withCursors()` |
 | gutter | boolean | Optional, defaults to true (render gutter). |
 | className | string |  |

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -33,6 +33,7 @@ import { type PluginRegistryComponent } from '../PluginRegistry/lib/types'
 import { type PlaceholdersVisibility } from '../TextbitRoot/TextbitContext'
 import { withSpelling } from './with/withSpelling'
 import type { SpellingError } from '../../types'
+import { withLang } from './with/lang'
 
 export interface TextbitEditableProps extends PropsWithChildren {
   onChange?: (value: Descendant[]) => void
@@ -41,6 +42,7 @@ export interface TextbitEditableProps extends PropsWithChildren {
   yjsEditor?: Editor
   gutter?: boolean
   dir?: 'ltr' | 'rtl'
+  lang?: string
   className?: string
   readOnly?: boolean
 }
@@ -52,6 +54,7 @@ export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(
   onSpellcheck,
   yjsEditor,
   dir = 'ltr',
+  lang,
   className = '',
   readOnly = false
 }: TextbitEditableProps, ref: React.LegacyRef<HTMLDivElement>) {
@@ -66,6 +69,7 @@ export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(
       withHistory(e)
     }
     withReact(e)
+    withLang(e, lang)
     withSpelling(e, onSpellcheck, spellcheckDebounceTimeout)
     withInline(e)
     withInsertText(e, plugins)

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -37,7 +37,7 @@ import { withLang } from './with/lang'
 
 export interface TextbitEditableProps extends PropsWithChildren {
   onChange?: (value: Descendant[]) => void
-  onSpellcheck?: (texts: string[]) => Promise<Omit<SpellingError, 'id'>[][]>
+  onSpellcheck?: (texts: { lang: string, text: string }[]) => Promise<Omit<SpellingError, 'id'>[][]>
   value?: Descendant[]
   yjsEditor?: Editor
   gutter?: boolean

--- a/lib/components/TextbitEditable/components/Element/ChildElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ChildElement.tsx
@@ -60,7 +60,7 @@ export const ChildElement = ({
 
       // Clone element and merge props
       return cloneElement(childElement, {
-        lang: (typeof lang === 'string' && lang.length) ? lang : editor.lang,
+        lang: (lang?.length) ? lang : editor.lang,
         'data-id': element.id,
         className: ['child', childElement.props?.className].filter(Boolean).join(' '),
         ...attributes
@@ -74,7 +74,7 @@ export const ChildElement = ({
   // Regular function component
   return (
     <div
-      lang={(typeof lang === 'string' && lang.length) ? lang : editor.lang}
+      lang={(lang?.length) ? lang : editor.lang}
       data-id={element.id}
       className='child'
       {...attributes}

--- a/lib/components/TextbitEditable/components/Element/ChildElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ChildElement.tsx
@@ -8,7 +8,7 @@ import {
   type ForwardedRef
 } from 'react'
 import { Node } from 'slate'
-import type { RenderElementProps } from 'slate-react'
+import { useSlateStatic, type RenderElementProps } from 'slate-react'
 import type { Plugin } from '../../../../types'
 
 interface ChildElementProps extends RenderElementProps {
@@ -38,7 +38,9 @@ export const ChildElement = ({
   rootNode,
   options
 }: ChildElementProps): ReactElement => {
+  const editor = useSlateStatic()
   const { component: Component } = entry
+  const lang = element.properties?.lang
 
   // Check if the component is forwardRef
   if (isForwardRefComponent<ComponentProps>(Component)) {
@@ -58,6 +60,7 @@ export const ChildElement = ({
 
       // Clone element and merge props
       return cloneElement(childElement, {
+        lang: (typeof lang === 'string' && lang.length) ? lang : editor.lang,
         'data-id': element.id,
         className: ['child', childElement.props?.className].filter(Boolean).join(' '),
         ...attributes
@@ -70,7 +73,12 @@ export const ChildElement = ({
 
   // Regular function component
   return (
-    <div className='child' data-id={element.id} {...attributes}>
+    <div
+      lang={(typeof lang === 'string' && lang.length) ? lang : editor.lang}
+      data-id={element.id}
+      className='child'
+      {...attributes}
+    >
       <Component element={element} rootNode={rootNode} options={options}>
         {children}
       </Component>

--- a/lib/components/TextbitEditable/components/Element/ParentElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ParentElement.tsx
@@ -1,4 +1,4 @@
-import { useSelected, type RenderElementProps } from 'slate-react'
+import { useSelected, useSlateStatic, type RenderElementProps } from 'slate-react'
 import { Droppable } from './Droppable'
 import type { Plugin } from '../../../../types'
 
@@ -16,7 +16,10 @@ interface ParentElementProps extends RenderElementProps {
  */
 export const ParentElement = (renderProps: ParentElementProps) => {
   const selected = useSelected()
+  const editor = useSlateStatic()
   const { element, attributes, entry } = renderProps
+
+  const lang = renderProps.element.properties?.lang
 
   /*
    * Class "relative" is needed for slate default placeholder to be positioned correctly.
@@ -27,6 +30,7 @@ export const ParentElement = (renderProps: ParentElementProps) => {
   return (
     <Droppable element={element}>
       <div
+        lang={(typeof lang === 'string' && lang.length) ? lang : editor.lang}
         data-id={element.id}
         data-state={selected ? 'active' : 'inactive'}
         className={`${element.class} ${element.type} ${entry.class} relative group`}

--- a/lib/components/TextbitEditable/components/Element/ParentElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ParentElement.tsx
@@ -30,7 +30,7 @@ export const ParentElement = (renderProps: ParentElementProps) => {
   return (
     <Droppable element={element}>
       <div
-        lang={(typeof lang === 'string' && lang.length) ? lang : editor.lang}
+        lang={(lang?.length) ? lang : editor.lang}
         data-id={element.id}
         data-state={selected ? 'active' : 'inactive'}
         className={`${element.class} ${element.type} ${entry.class} relative group`}

--- a/lib/components/TextbitEditable/with/lang.ts
+++ b/lib/components/TextbitEditable/with/lang.ts
@@ -1,0 +1,6 @@
+import { Editor } from 'slate'
+
+export const withLang = (editor: Editor, lang?: string) => {
+  editor.lang = lang || document?.documentElement?.lang || navigator.language || 'en'
+  return editor
+}

--- a/lib/components/TextbitEditable/with/withSpelling.ts
+++ b/lib/components/TextbitEditable/with/withSpelling.ts
@@ -82,7 +82,7 @@ async function updateSpellcheck(
       // New node, or existing changed node, spellchecking needed
       const isEmpty = text.trim() === ''
       tracker.set(node.id, {
-        lang: (typeof lang === 'string' && lang.length) ? lang : editor.lang,
+        lang: (lang?.length) ? lang : editor.lang,
         text,
         errors: [],
         check: !isEmpty

--- a/lib/types/extends.ts
+++ b/lib/types/extends.ts
@@ -24,6 +24,7 @@ export type TBEditor = BaseEditor & ReactEditor & HistoryEditor & {
     errors: SpellingError[]
   }>
   spellcheck: () => void
+  lang: string
 }
 
 /**

--- a/lib/types/extends.ts
+++ b/lib/types/extends.ts
@@ -20,6 +20,7 @@ export type SpellingError = {
 
 export type TBEditor = BaseEditor & ReactEditor & HistoryEditor & {
   spellingLookupTable: Map<string, {
+    lang: string
     text: string
     errors: SpellingError[]
   }>

--- a/lib/types/extends.ts
+++ b/lib/types/extends.ts
@@ -38,6 +38,8 @@ export type TBElement = BaseElement & {
   type: string
   hotKey?: string
   properties?: {
+    lang?: string
+  } & {
     [key: string]: string | number | boolean
   }
   attributes?: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,25 @@ const initialValue: Descendant[] = [
   },
   {
     type: 'core/text',
+    id: '538343b5-badd-48f9-8ef0-1219891b6061',
+    class: 'text',
+    properties: {
+      lang: 'sv-se'
+    },
+    children: [
+      { text: 'Här följer text som är på svenska och följaktligen bör stavningskollas på svenska. ' },
+      {
+        text: 'Stavningskontrollen fungerar '
+      },
+      {
+        text: 'korrrekt',
+        'core/italic': true
+      },
+      { text: ' på flera språk.' }
+    ]
+  },
+  {
+    type: 'core/text',
     id: '538343b5-badd-48f9-8ef0-1219891b6066',
     class: 'text',
     children: [
@@ -99,25 +118,6 @@ const initialValue: Descendant[] = [
     class: 'text',
     children: [
       { text: '' }
-    ]
-  },
-  {
-    type: 'core/text',
-    id: '538343b5-badd-48f9-8ef0-1219891b6061',
-    class: 'text',
-    children: [
-      { text: 'An example paragraph that contains text that is a wee bit ' },
-      {
-        text: 'stronger',
-        'core/bold': true,
-        'core/italic': true
-      },
-      { text: ' than normal but also text that is somewhat ' },
-      {
-        text: 'emphasized',
-        'core/italic': true
-      },
-      { text: ' compared to the normal styled text found elsewhere in the document.' }
     ]
   }
 ]
@@ -191,10 +191,17 @@ export function App() {
 
 type SpellcheckedText = SpellingError[]
 
-function fakeSpellChecker(text: string): SpellcheckedText {
+function fakeSpellChecker(text: string, lang: string): SpellcheckedText {
   const result: SpellcheckedText = []
 
-  const allSuggestions: Record<string, Suggestion[]> = {
+  const svSuggestions: Record<string, Suggestion[]> = {
+    korrrekt: [
+      { text: 'korrekt' },
+      { text: 'korrektur' }
+    ]
+  }
+
+  const enSuggestions: Record<string, Suggestion[]> = {
     wee: [
       { text: 'we', description: 'Alternative single word' },
       { text: 'teeny', description: 'Alternative single word' },
@@ -209,12 +216,15 @@ function fakeSpellChecker(text: string): SpellcheckedText {
     ]
   }
 
-  for (const misspelled of Object.keys(allSuggestions)) {
+  // Choose suggestions dict based on lang
+  const suggestions = (lang.startsWith('sv')) ? svSuggestions : enSuggestions
+
+  for (const misspelled of Object.keys(suggestions)) {
     if (text.toLowerCase().includes(misspelled.toLowerCase())) {
       result.push({
         id: '',
         text: misspelled,
-        suggestions: allSuggestions[misspelled]
+        suggestions: suggestions[misspelled]
       })
     }
   }
@@ -249,9 +259,10 @@ function Editor({ initialValue }: { initialValue: Descendant[] }) {
             setValue(value)
           }}
           onSpellcheck={(texts) => {
+            debugger
             return new Promise((resolve) => {
               setTimeout(() => {
-                resolve(texts.map(fakeSpellChecker))
+                resolve(texts.map((text) => fakeSpellChecker(text.text, text.lang)))
               }, 100)
             })
           }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,6 +179,7 @@ export function App() {
           verbose={true}
           debounce={1000}
           plugins={[...Textbit.Plugins.map((p) => p())]}
+          locale='sv_SE'
         >
           <strong>Long debounce</strong>
           <Editor initialValue={initialValue} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,7 +179,6 @@ export function App() {
           verbose={true}
           debounce={1000}
           plugins={[...Textbit.Plugins.map((p) => p())]}
-          locale='sv_SE'
         >
           <strong>Long debounce</strong>
           <Editor initialValue={initialValue} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -259,7 +259,6 @@ function Editor({ initialValue }: { initialValue: Descendant[] }) {
             setValue(value)
           }}
           onSpellcheck={(texts) => {
-            debugger
             return new Promise((resolve) => {
               setTimeout(() => {
                 resolve(texts.map((text) => fakeSpellChecker(text.text, text.lang)))

--- a/src/plugins/Link/components/Link.tsx
+++ b/src/plugins/Link/components/Link.tsx
@@ -28,9 +28,8 @@ export const Link = ({ children, element }: Plugin.ComponentProps): JSX.Element 
   })
 
   return (
-    // FIXME: @ts-expect-error FIXME:
     <a
-      {...attributes}
+      {...element.attributes}
       href={url}
       onClick={(event) => {
         if (event.ctrlKey || event.metaKey) {


### PR DESCRIPTION
1. Add lang prop to Textbit.Editable component (optional, defaults to document language, then browser language, then "en")
2. Store lang value in editor object so that it is available everywhere, consumers etc
3. Add lang property support to all elements to allow elements (paragraphs etc) to have different languages defined
4. Change spelling interface so that it sends the language of the texts to be spellchecked allowing to spellcheck different text elements with different languages in the same document.