### PR TITLE
Feature/ele 1252 pasting text, html, slate or fragments should not ignore negative allowBreak constraints

### DIFF
--- a/lib/components/TextbitEditable/with/insertHtml.ts
+++ b/lib/components/TextbitEditable/with/insertHtml.ts
@@ -34,7 +34,8 @@ export const withInsertHtml = (
     let allowBreaks = true
 
     if (selection && Range.isCollapsed(selection)) {
-      const node = getSelectedNodes(editor)?.[0]
+      const nodes = getSelectedNodes(editor)
+      const node = nodes.length && nodes[nodes.length - 1]
       if (Element.isElement(node)) {
         const component = components.get(node.type || '')
         allowBreaks = component?.componentEntry.constraints?.allowBreak ?? true

--- a/lib/components/TextbitEditable/with/insertHtml.ts
+++ b/lib/components/TextbitEditable/with/insertHtml.ts
@@ -30,7 +30,6 @@ export const withInsertHtml = (
     // Figure out if pasting contains line breaks and if that is allowed,
     // then we can't allow Slate to handle slate fragments. Instead we will
     // treat it as text and paste without linebreaks.
-    // FIXME: Should the same logic be for non collapsed selections?
     let allowBreaks = true
 
     if (selection && Range.isCollapsed(selection)) {

--- a/lib/components/TextbitEditable/with/insertHtml.ts
+++ b/lib/components/TextbitEditable/with/insertHtml.ts
@@ -4,7 +4,7 @@ import { type Plugin } from '../../../types'
 import { pasteToConsumers } from '../../../lib/pasteToConsumer'
 import { type PluginRegistryComponent } from '../../../components/PluginRegistry/lib/types'
 import { TextbitPlugin } from '../../../lib'
-import { getSelectedNodeEntries, getSelectedNodes } from '../../../lib/utils'
+import { getSelectedNodes } from '../../../lib/utils'
 
 type Consumers = {
   consumes: Plugin.ConsumesFunction

--- a/lib/components/TextbitEditable/with/insertText.ts
+++ b/lib/components/TextbitEditable/with/insertText.ts
@@ -29,7 +29,7 @@ export const withInsertText = (editor: Editor, plugins: Plugin.Definition[]) => 
       return
     }
 
-    handle.then((response) => {
+    void handle.then((response) => {
       const newText = typeof response === 'string' ? response : text
       insertText(newText)
     })

--- a/lib/lib/normalizeWhitespace.ts
+++ b/lib/lib/normalizeWhitespace.ts
@@ -1,0 +1,32 @@
+/**
+ * Normalizes all whitespace in a string by making sure it cannot break
+ * into multiple paragraphs.
+ *
+ * Tabs are removed as they normally are problematic in a single line
+ * context in a field etc in the editor.
+ *
+ * We specifically don't want to remove non breaking spaces (\u00A0)
+ * or any other specialized spacers that are used to keep numbers
+ * together or used in different languages.
+ *
+ * 1. Replacing all whitespace characters (tabs, line breaks, etc.) with spaces
+ * 2. Reducing multiple consecutive spaces to a single space
+ */
+export function normalizeWhitespace(text: string): string {
+  if (!text) {
+    return text
+  }
+
+  // Replace all whitespace characters with a regular space
+  // - \n (line feed)
+  // - \r (carriage return)
+  // - \t (tab)
+  // - \f (form feed)
+  // - \v (vertical tab)
+  // - \u2028 (line separator)
+  // - \u2029 (paragraph separator)
+  const replacedWhitespace = text.replace(/[\n\r\t\f\v\u2028\u2029]+/g, ' ')
+
+  // Then, replace any sequences of spaces with a single space
+  return replacedWhitespace.replace(/\s+/g, ' ')
+}

--- a/lib/lib/pasteToParagraphs.ts
+++ b/lib/lib/pasteToParagraphs.ts
@@ -3,6 +3,7 @@ import * as uuid from 'uuid'
 import { componentConstraints } from './componentConstraints'
 import { TextbitEditor } from './textbit-editor'
 import { type PluginRegistryComponent } from '../components/PluginRegistry/lib/types'
+import { normalizeWhitespace } from './normalizeWhitespace'
 
 
 export function pasteToParagraphs(
@@ -22,13 +23,6 @@ export function pasteToParagraphs(
     return false
   }
 
-  // Split text into paragraphs based on newlines or carriage returns
-  const paragraphedText = text.replace(/[\r\n]{2,}/g, '\n').trim()
-  const paragraphs = paragraphedText.split('\n').map((t) => t.trim())
-  if (paragraphs.length < 2) {
-    return false
-  }
-
   // Find node and which component this is related to
   const parent = TextbitEditor.parent(editor, selection)
   const node = parent[0] as Element
@@ -43,9 +37,14 @@ export function pasteToParagraphs(
   }
 
   // If we don't allow break, let default put all text in same node
+  let paragraphs
   const { allowBreak } = componentConstraints(tbComponent)
   if (!allowBreak) {
-    return false
+    paragraphs = [normalizeWhitespace(text)]
+  } else {
+    // Split text into paragraphs based on newlines or carriage returns
+    const paragraphedText = text.replace(/[\r\n]{2,}/g, '\n').trim()
+    paragraphs = paragraphedText.split('\n').map((t) => t.trim())
   }
 
   // If we have a longer path, paste happens in a child node, all

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,8 @@ import Textbit, {
 import {
   BulletList,
   NumberList,
-  Link
+  Link,
+  CodeBlock
 } from './plugins'
 
 import './editor-variables.css'
@@ -72,6 +73,23 @@ const initialValue: Descendant[] = [
     class: 'text',
     children: [
       { text: '' }
+    ]
+  },
+  {
+    type: 'core/codeblock',
+    id: '538345e5-aad1-58f9-8ef0-b2198a1a60a2',
+    class: 'block',
+    children: [
+      {
+        type: 'core/codeblock/title',
+        class: 'text',
+        children: [{ text: '' }]
+      },
+      {
+        type: 'core/codeblock/body',
+        class: 'text',
+        children: [{ text: '' }]
+      }
     ]
   },
   {
@@ -165,7 +183,8 @@ export function App() {
             NumberList(),
             Link({
               option1: true // Example option
-            })
+            }),
+            CodeBlock()
           ]}
         >
           <strong>Multiple placeholders</strong>
@@ -294,33 +313,33 @@ function Editor({ initialValue }: { initialValue: Descendant[] }) {
 
           {!!spelling && (
             <ContextMenu.Root className='textbit-contextmenu'>
-                <ContextMenu.Group className='textbit-contextmenu-group' key='spelling-suggestions'>
-                  {spelling?.suggestions.length === 0 && (
-                    <ContextMenu.Item className='textbit-contextmenu-item'>
-                      No spelling suggestions
+              <ContextMenu.Group className='textbit-contextmenu-group' key='spelling-suggestions'>
+                {spelling?.suggestions.length === 0 && (
+                  <ContextMenu.Item className='textbit-contextmenu-item'>
+                    No spelling suggestions
+                  </ContextMenu.Item>
+                )}
+
+                {spelling?.suggestions.map((suggestion) => {
+                  const { text, description } = suggestion
+
+                  return (
+                    <ContextMenu.Item
+                      className='textbit-contextmenu-item'
+                      key={text}
+                      func={() => {
+                        spelling.apply(text)
+                      }}
+                    >
+                      {text}
+                      {' '}
+                      -
+                      {' '}
+                      <em>{description}</em>
                     </ContextMenu.Item>
-                  )}
-
-                  {spelling?.suggestions.map((suggestion) => {
-                    const { text, description } = suggestion
-
-                    return (
-                      <ContextMenu.Item
-                        className='textbit-contextmenu-item'
-                        key={text}
-                        func={() => {
-                          spelling.apply(text)
-                        }}
-                      >
-                        {text}
-                        {' '}
-                        -
-                        {' '}
-                        <em>{description}</em>
-                      </ContextMenu.Item>
-                    )
-                  })}
-                </ContextMenu.Group>
+                  )
+                })}
+              </ContextMenu.Group>
             </ContextMenu.Root>
           )}
           <Toolbar.Root className='textbit-contexttools-menu'>

--- a/src/plugins/CodeBlock/components/CodeBlock.tsx
+++ b/src/plugins/CodeBlock/components/CodeBlock.tsx
@@ -1,0 +1,14 @@
+import type { Plugin } from '@ttab/textbit'
+
+export const CodeBlock = ({ children }: Plugin.ComponentProps): JSX.Element => {
+  return (
+    <div style={{
+      border: '1px solid gray',
+      borderRadius: '6px',
+      padding: '2px 4px'
+    }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/plugins/CodeBlock/components/CodeBlockBody.tsx
+++ b/src/plugins/CodeBlock/components/CodeBlockBody.tsx
@@ -1,0 +1,18 @@
+import type { Plugin } from '@ttab/textbit'
+
+// TODO: Use https://prismjs.com/ to display code
+export const CodeBlockBody = ({ children }: Plugin.ComponentProps): JSX.Element => {
+  return (
+    <code style={{
+      display: 'block',
+      whiteSpace: 'pre',
+      padding: '4px',
+      fontSize: '80%',
+      backgroundColor: '#eee',
+      fontFamily: 'monospace'
+    }}
+    >
+      {children}
+    </code>
+  )
+}

--- a/src/plugins/CodeBlock/components/CodeBlockTitle.tsx
+++ b/src/plugins/CodeBlock/components/CodeBlockTitle.tsx
@@ -1,0 +1,17 @@
+import type { Plugin } from '@ttab/textbit'
+
+export const CodeBlockTitle = ({ children }: Plugin.ComponentProps): JSX.Element => {
+  return (
+    <div
+      draggable={false}
+      style={{
+        border: '1px solid #aaa',
+        backgroundColor: '#eee',
+        fontFamily: 'sans-serif',
+        padding: '2px 4px'
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/plugins/CodeBlock/components/index.tsx
+++ b/src/plugins/CodeBlock/components/index.tsx
@@ -1,0 +1,3 @@
+export { CodeBlock } from './CodeBlock'
+export { CodeBlockBody } from './CodeBlockBody'
+export { CodeBlockTitle } from './CodeBlockTitle'

--- a/src/plugins/CodeBlock/index.tsx
+++ b/src/plugins/CodeBlock/index.tsx
@@ -1,0 +1,48 @@
+import type {
+  Plugin,
+  TBEditor,
+  TBElement,
+  TBText
+} from '@ttab/textbit'
+
+import {
+  CodeBlock as CodeBlockComponent,
+  CodeBlockBody as CodeBlockBodyComponent,
+  CodeBlockTitle as CodeBlockTitleComponent
+} from './components'
+
+/**
+ * Define Slate CustomTypes to be Textbit types
+ */
+declare module 'slate' {
+  interface CustomTypes {
+    Editor: TBEditor
+    Element: TBElement
+    Text: TBText
+  }
+}
+
+export const CodeBlock: Plugin.InitFunction = () => {
+  return {
+    class: 'textblock',
+    name: 'core/codeblock',
+    componentEntry: {
+      class: 'textblock',
+      component: CodeBlockComponent,
+      children: [
+        {
+          type: 'title',
+          class: 'text',
+          component: CodeBlockTitleComponent,
+          constraints: {
+            allowBreak: false
+          }
+        },
+        {
+          type: 'body',
+          class: 'text',
+          component: CodeBlockBodyComponent
+        }]
+    }
+  }
+}

--- a/src/plugins/index.tsx
+++ b/src/plugins/index.tsx
@@ -6,3 +6,7 @@ export {
 export {
   Link
 } from './Link'
+
+export {
+  CodeBlock
+} from './CodeBlock'


### PR DESCRIPTION
If constraints says it does not allow breaks, linebreaks should be filtered out. Added test plugin for manual testing.