### PR TITLE
Feature/ele 1253 improve block image factbox handling in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Plugins can be either
 | leaf | Bold, italic, etc. |
 | inline | Inline blocks in the text, like links. |
 | text | Normal text of various types. |
-| textblock | Very similar to a block, but used for text that is not draggable, like code or a blockquote. |
+| _textblock_ | **deprecated** _Use block instead._ |
 | block | Regular block elements like image, video. Automatically becomes draggable. |
 | void | Non editable objects, like a spinning loader. Should seldom be used.|
 | generic| Non rendered plugins. Like transforming input characters. |

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Can be used to wrap all elements in plugin components. Provides data state attri
 
 | Name | Value | Description |
 | ----------- | ----------- | ----------- |
-| [data-state] | "selected" \| "active" \| "inactive" | The value "selected" indicates that that the block node is selected as a whole. Values "active" or "inactive" indicates whether the cursor is in the element or the element is part of a selection. |
+| [data-state] | "active" \| "inactive" | The values "active" or "inactive" indicates whether the cursor is in the element or the element is part of a selection. |
 
 ### Styling spelling errors
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Can be used to wrap all elements in plugin components. Provides data state attri
 
 | Name | Value | Description |
 | ----------- | ----------- | ----------- |
-| [data-state] | "active" \| "inactive" | Indicate that cursor is in element or element is part of a selection. |
+| [data-state] | "selected" \| "active" \| "inactive" | The value "selected" indicates that that the block node is selected as a whole. Values "active" or "inactive" indicates whether the cursor is in the element or the element is part of a selection. |
 
 ### Styling spelling errors
 

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -32,6 +32,7 @@ import { type PlaceholdersVisibility } from '../TextbitRoot/TextbitContext'
 import { withSpelling } from './with/withSpelling'
 import type { SpellingError } from '../../types'
 import { withLang } from './with/lang'
+import { withDeletionManagement } from './with/withDeletionManagement'
 
 export interface TextbitEditableProps extends PropsWithChildren {
   onChange?: (value: Descendant[]) => void
@@ -77,6 +78,7 @@ export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(
     withInsertBreak(e, components)
     withInsertHtml(e, components, plugins)
     withUniqueIds(e)
+    withDeletionManagement(e)
     return e
   }, [])
 

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -7,14 +7,12 @@ import {
 } from 'react'
 import { createEditor, Editor as SlateEditor, type Descendant, Editor, type NodeEntry, Node, Text, Range } from 'slate'
 import { withHistory } from 'slate-history'
-import { type RenderElementProps, type RenderLeafProps, withReact } from 'slate-react'
+import { withReact } from 'slate-react'
 import { YHistoryEditor } from '@slate-yjs/core'
 
 import { DragStateProvider } from './DragStateProvider'
 import { withInline } from './with/inline'
 
-import { ElementComponent } from './components/Element'
-import { Leaf } from './components/Leaf'
 import { withInsertText } from './with/insertText'
 import { withNormalizeNode } from './with/normalizeNode'
 import { withEditableVoids } from './with/editableVoids'
@@ -82,14 +80,6 @@ export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(
     return e
   }, [])
 
-  const renderSlateElement = useCallback((props: RenderElementProps) => {
-    return ElementComponent(props)
-  }, [])
-
-  const renderLeafComponent = useCallback((props: RenderLeafProps) => {
-    return Leaf(props)
-  }, [])
-
   // Debounced onChange handler
   const onChangeCallback = useCallback(
     debounce((value: Descendant[]) => {
@@ -126,8 +116,6 @@ export const TextbitEditable = forwardRef<HTMLDivElement, TextbitEditableProps>(
                 onDecorate={(entry: NodeEntry) => {
                   return decorate(textbitEditor, entry, components, placeholders)
                 }}
-                renderSlateElement={renderSlateElement}
-                renderLeafComponent={renderLeafComponent}
                 textbitEditor={textbitEditor}
                 actions={actions}
               />

--- a/lib/components/TextbitEditable/components/Element/ParentElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ParentElement.tsx
@@ -6,6 +6,7 @@ import type { Plugin } from '../../../../types'
 interface ParentElementProps extends RenderElementProps {
   entry: Plugin.ComponentEntry
   options?: Record<string, unknown>
+  isSelected?: boolean
 }
 
 /**
@@ -15,9 +16,9 @@ interface ParentElementProps extends RenderElementProps {
  * @returns JSX.Element
  */
 export const ParentElement = (renderProps: ParentElementProps) => {
-  const selected = useSelected()
+  const active = useSelected() // Whether cursor is inside block
   const editor = useSlateStatic()
-  const { element, attributes, entry } = renderProps
+  const { element, attributes, entry, isSelected = false } = renderProps
 
   /*
    * Class "relative" is needed for slate default placeholder to be positioned correctly.
@@ -25,14 +26,27 @@ export const ParentElement = (renderProps: ParentElementProps) => {
    * selectors like "group-data-[state='active']:ring-1"
    */
 
+  /*
+   * inactive : cursor is elsewhere
+   * active   : cursor is inside
+   * selected : cursor is "around", whole block is selected
+   */
+  let dataState
+  if (isSelected) {
+    dataState = 'selected'
+  } else {
+    dataState = active ? 'active' : 'inactive'
+  }
+
   return (
     <Droppable element={element}>
       <div
         lang={renderProps.element.lang || editor.lang}
         data-id={element.id}
-        data-state={selected ? 'active' : 'inactive'}
+        data-state={dataState}
         className={`${element.class} ${element.type} ${entry.class} relative group`}
         {...attributes}
+        contentEditable={isSelected ? false : undefined}
       >
         <entry.component {...renderProps} editor={editor} />
       </div>

--- a/lib/components/TextbitEditable/components/Element/ParentElement.tsx
+++ b/lib/components/TextbitEditable/components/Element/ParentElement.tsx
@@ -6,7 +6,6 @@ import type { Plugin } from '../../../../types'
 interface ParentElementProps extends RenderElementProps {
   entry: Plugin.ComponentEntry
   options?: Record<string, unknown>
-  isSelected?: boolean
 }
 
 /**
@@ -18,7 +17,7 @@ interface ParentElementProps extends RenderElementProps {
 export const ParentElement = (renderProps: ParentElementProps) => {
   const active = useSelected() // Whether cursor is inside block
   const editor = useSlateStatic()
-  const { element, attributes, entry, isSelected = false } = renderProps
+  const { element, attributes, entry } = renderProps
 
   /*
    * Class "relative" is needed for slate default placeholder to be positioned correctly.
@@ -29,24 +28,15 @@ export const ParentElement = (renderProps: ParentElementProps) => {
   /*
    * inactive : cursor is elsewhere
    * active   : cursor is inside
-   * selected : cursor is "around", whole block is selected
    */
-  let dataState
-  if (isSelected) {
-    dataState = 'selected'
-  } else {
-    dataState = active ? 'active' : 'inactive'
-  }
-
   return (
     <Droppable element={element}>
       <div
         lang={renderProps.element.lang || editor.lang}
         data-id={element.id}
-        data-state={dataState}
+        data-state={active ? 'active' : 'inactive'}
         className={`${element.class} ${element.type} ${entry.class} relative group`}
         {...attributes}
-        contentEditable={isSelected ? false : undefined}
       >
         <entry.component {...renderProps} editor={editor} />
       </div>

--- a/lib/components/TextbitEditable/components/Element/index.tsx
+++ b/lib/components/TextbitEditable/components/Element/index.tsx
@@ -1,4 +1,4 @@
-import { Node } from 'slate'
+import { Node, Path } from 'slate'
 import { type RenderElementProps, ReactEditor, useSlateStatic } from 'slate-react'
 import { ChildElement } from './ChildElement'
 import { ParentElement } from './ParentElement'
@@ -9,9 +9,10 @@ import { usePluginRegistry } from '../../../../components/PluginRegistry'
 /**
  * Render a custom Slate element
  */
-export const ElementComponent = (props: RenderElementProps) => {
+export const ElementComponent = (props: RenderElementProps & {
+  selectedBlockPath?: Path
+}) => {
   const editor = useSlateStatic()
-
   const { element } = props
   const { components } = usePluginRegistry()
   const component = components.get(element.type)
@@ -22,6 +23,9 @@ export const ElementComponent = (props: RenderElementProps) => {
   // Get the path for this element
   const path = ReactEditor.findPath(editor, element)
 
+  // Get selected block path if exists
+  const selectedBlockPath = props.selectedBlockPath
+
   // No parents found in path, render a root element
   if (path.length === 1) {
     return (
@@ -29,6 +33,7 @@ export const ElementComponent = (props: RenderElementProps) => {
         {...props}
         entry={component.componentEntry}
         options={component.pluginOptions}
+        isSelected={selectedBlockPath && Path.equals(path, selectedBlockPath)}
       />
     )
   }

--- a/lib/components/TextbitEditable/components/Element/index.tsx
+++ b/lib/components/TextbitEditable/components/Element/index.tsx
@@ -23,9 +23,6 @@ export const ElementComponent = (props: RenderElementProps & {
   // Get the path for this element
   const path = ReactEditor.findPath(editor, element)
 
-  // Get selected block path if exists
-  const selectedBlockPath = props.selectedBlockPath
-
   // No parents found in path, render a root element
   if (path.length === 1) {
     return (
@@ -33,7 +30,6 @@ export const ElementComponent = (props: RenderElementProps & {
         {...props}
         entry={component.componentEntry}
         options={component.pluginOptions}
-        isSelected={selectedBlockPath && Path.equals(path, selectedBlockPath)}
       />
     )
   }

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -236,15 +236,11 @@ function handleBlockOperations(
   if (blockSelection && ['Backspace', 'Delete'].includes(event.key)) {
     event.preventDefault()
 
-    const [blockNode] = Editor.node(textbitEditor, blockSelection.path)
-    if (SlateElement.isElement(blockNode)) {
-      Transforms.removeNodes(textbitEditor, {
-        at: blockSelection.path,
-        match: (n) => SlateElement.isElement(n) && TextbitElement.isBlock(n)
-      })
+    Transforms.removeNodes(textbitEditor, {
+      at: [blockSelection.path[0]]
+    })
 
-      setBlockSelection(undefined)
-    }
+    setBlockSelection(undefined)
     return
   }
 

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -178,43 +178,6 @@ function handleBlockOperations(
   textbitEditor: Editor,
   event: React.KeyboardEvent<HTMLDivElement>
 ) {
-  // If backspace without block selection, don't allow backspace in offset 0 of first child
-  // FIXME: This should be turned into a constraint in the plugin component defenitions
-  // which should also handle delete.
-  // FIXME: Move this ot withBlockDeletion.ts!!!
-  if (event.key === 'Backspace') {
-    const { selection } = textbitEditor
-
-    if (selection && Range.isCollapsed(selection)) {
-      const focusPath = selection.focus.path
-
-      // Check if offset is 0
-      if (selection.focus.offset !== 0) return
-
-      // Find the top-level block above the selection
-      const [blockNode, blockPath] = Editor.above(textbitEditor, {
-        at: focusPath,
-        match: (n) => TextbitElement.isBlock(n)
-      }) ?? []
-
-      if (!blockNode || !blockPath) return
-
-      // Get the path to the first text node in the block
-      const firstTextEntry = Editor.first(textbitEditor, blockPath)
-
-      if (!firstTextEntry) return
-
-      const [, firstTextPath] = firstTextEntry
-
-      if (Path.equals(focusPath, firstTextPath) && selection.focus.offset === 0) {
-        event.preventDefault()
-      }
-    }
-
-    return
-  }
-
-  // FIXME: Merge this with below enter or move to a withBreak
   if (event.key === 'Enter') {
     const { selection } = textbitEditor
     if (!selection || !Range.isCollapsed(selection)) return
@@ -231,11 +194,7 @@ function handleBlockOperations(
       if (Point.equals(selection.anchor, blockEnd)) {
         const after = Path.next(path)
         Transforms.select(textbitEditor, blockEnd)
-        // Transforms.insertNodes(
-        //   textbitEditor,
-        //   { type: 'paragraph', children: [{ text: '' }] },
-        //   { at: after }
-        // )
+
         Transforms.insertNodes(textbitEditor, {
           id: crypto.randomUUID(),
           class: 'text',
@@ -249,20 +208,4 @@ function handleBlockOperations(
     }
     return
   }
-
-
-  // 4. Handle insertion of new line after selected block
-  // if (blockSelection && event.key === 'Enter') {
-  //   const nextPath = Path.next(blockSelection.path)
-  //   Transforms.insertNodes(textbitEditor, {
-  //     id: crypto.randomUUID(),
-  //     class: 'text',
-  //     type: 'core/text',
-  //     children: [{ text: '' }]
-  //   }, { at: nextPath })
-
-  //   Transforms.select(textbitEditor, Editor.start(textbitEditor, nextPath))
-  //   setBlockSelection(undefined)
-  //   event.preventDefault()
-  // }
 }

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, forwardRef, useState, useCallback } from 'react'
-import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry, Node, type BaseRange, Path, Location, Point } from 'slate'
+import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry, Node, type BaseRange, Path, Point } from 'slate'
 import { Editable, ReactEditor, type RenderElementProps, type RenderLeafProps, useFocused } from 'slate-react'
 import { toggleLeaf } from '../../../../lib/toggleLeaf'
 import type { PluginRegistryAction } from '../../../PluginRegistry/lib/types'

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -208,6 +208,8 @@ function handleNavigation(
 
       event.preventDefault()
       setBlockSelection(newBlockSelection)
+    } else if (blockSelection) {
+      setBlockSelection(undefined)
     }
   }
 

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -355,11 +355,11 @@ function getNextPoint(editor: Editor, selection: BaseRange, key: NavigationKey) 
   if (key === 'ArrowRight') {
     return Editor.after(editor, selection.focus.path)
   } else if (key === 'ArrowDown') {
-    return Editor.after(editor, selection.focus.path)
+    return Editor.after(editor, selection.focus.path, { unit: 'line' })
   } else if (key === 'ArrowLeft') {
     return Editor.before(editor, selection.focus.path)
   } else if (key === 'ArrowUp') {
-    return Editor.before(editor, selection.focus.path)
+    return Editor.before(editor, selection.focus.path, { unit: 'line' })
   }
 }
 

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -1,5 +1,17 @@
 import React, { useRef, forwardRef, useState, useCallback } from 'react'
-import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry, Node, type BaseRange, Path, Point, Selection } from 'slate'
+import {
+  Editor as SlateEditor,
+  Transforms,
+  Element as SlateElement,
+  Editor,
+  Text,
+  Range,
+  type NodeEntry,
+  Node,
+  type BaseRange,
+  Path,
+  Point
+} from 'slate'
 import { Editable, ReactEditor, type RenderElementProps, type RenderLeafProps, useFocused } from 'slate-react'
 import { toggleLeaf } from '../../../../lib/toggleLeaf'
 import type { PluginRegistryAction } from '../../../PluginRegistry/lib/types'

--- a/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
+++ b/lib/components/TextbitEditable/components/Slate/SlateEditable.tsx
@@ -1,16 +1,16 @@
-import React, { useRef, forwardRef } from 'react'
-import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry } from 'slate'
-import { Editable, ReactEditor, type RenderElementProps, type RenderLeafProps, useFocused } from 'slate-react'
+import React, { useRef, forwardRef, useState, useCallback } from 'react'
+import { Editor as SlateEditor, Transforms, Element as SlateElement, Editor, Text, Range, type NodeEntry, Node, BaseRange, Path } from 'slate'
+import { Editable, ReactEditor, type RenderElementProps, type RenderLeafProps, useFocused, useSlateStatic } from 'slate-react'
 import { toggleLeaf } from '../../../../lib/toggleLeaf'
 import type { PluginRegistryAction } from '../../../PluginRegistry/lib/types'
 import { useTextbit } from '../../../../components/TextbitRoot'
-import { TextbitEditor } from '../../../../lib'
+import { TextbitEditor, TextbitElement } from '../../../../lib'
 import { useContextMenu } from '../../../../hooks/useContextMenu'
+import { ElementComponent } from '../Element'
+import { Leaf } from '../Leaf'
 
 interface SlateEditableProps {
   className?: string
-  renderSlateElement: (props: RenderElementProps) => JSX.Element
-  renderLeafComponent: (props: RenderLeafProps) => JSX.Element
   textbitEditor: Editor
   actions: PluginRegistryAction[]
   autoFocus: boolean
@@ -22,8 +22,6 @@ interface SlateEditableProps {
 
 export const SlateEditable = forwardRef(function SlateEditable({
   className = '',
-  renderSlateElement,
-  renderLeafComponent,
   textbitEditor,
   actions,
   autoFocus,
@@ -35,8 +33,23 @@ export const SlateEditable = forwardRef(function SlateEditable({
   const focused = useFocused()
   const { placeholder } = useTextbit()
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const [blockSelection, setBlockSelection] = useState<{
+    edge: string
+    path: Path
+  } | undefined>(undefined)
 
   useContextMenu(wrapperRef)
+
+  const renderSlateElement = useCallback((props: RenderElementProps) => {
+    return ElementComponent({
+      ...props,
+      selectedBlockPath: blockSelection?.path
+    })
+  }, [blockSelection])
+
+  const renderLeafComponent = useCallback((props: RenderLeafProps) => {
+    return Leaf(props)
+  }, [])
 
   return (
     <div ref={wrapperRef}>
@@ -48,12 +61,47 @@ export const SlateEditable = forwardRef(function SlateEditable({
         className={className}
         renderElement={renderSlateElement}
         renderLeaf={renderLeafComponent}
-        onKeyDown={(event) => handleOnKeyDown(textbitEditor, actions, event)}
+        onKeyDown={(event) => {
+          if (['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+            const newBlockSelection = isMovingTowardsChild(textbitEditor, event.key)
+            if (!!newBlockSelection?.path !== !!blockSelection) {
+              if (blockSelection) {
+                // We are already inside the block and have a block selection. The real
+                // selection are already the first postion. So when we clear the block
+                // selection the current cursor position will be rendered correctly
+                event.preventDefault()
+              }
+
+              // Block selection will be cleared or set
+              setBlockSelection(newBlockSelection)
+            }
+          }
+
+          // Special cases
+          if (blockSelection && ['Backspace', 'Delete'].includes(event.key)) {
+            // FIXME: Handle special backspace case:
+            // Add check if we are in the first pos of the first child in block node children
+            // - then we should ignore the backspace.
+            console.log('REMOVE IT')
+          } else if (blockSelection && event.key === 'Enter') {
+            // FIXME: Handle special enter case:
+            // Add check if we are in the last pos of the last child in block node children
+            // and that child is a single line - then we also want to add line after.
+            console.log('Add line after')
+          }
+
+          handleOnKeyDown(textbitEditor, actions, event)
+        }}
         decorate={onDecorate}
         onBlur={onBlur}
         spellCheck={false}
         autoFocus={autoFocus}
         onMouseDown={(event) => {
+          // Always clear block selection
+          if (blockSelection) {
+            setBlockSelection(undefined)
+          }
+
           if (!focused && !textbitEditor.selection) {
             // Especially Firefox does not set it correctly on first click
             const range = ReactEditor.findEventRange(textbitEditor, event)
@@ -136,5 +184,65 @@ function handleOnKeyDown(editor: SlateEditor, actions: PluginRegistryAction[], e
       )
     }
     break
+  }
+}
+
+
+function isMovingTowardsChild(editor: Editor, key: string): {
+  edge: string
+  path: Path
+} | undefined {
+  const { selection } = editor
+  if (!selection || !selection.focus) return
+
+  const [node] = Editor.node(editor, selection.focus.path)
+
+  // If we navigate "horisontally" and are not at the edges we can stop
+  if (key === 'ArrowRight' && selection.focus.offset !== Node.string(node).length) {
+    return
+  } else if (key === 'ArrowLeft' && selection.focus.offset !== 0) {
+    return
+  }
+
+  // Get the next point
+  const nextPoint = getNextPoint(editor, selection, key)
+  if (!nextPoint) return
+
+  const [nextNode] = Editor.node(editor, [nextPoint.path[0]])
+  const [nextChildNode] = Editor.node(editor, nextPoint.path)
+
+  if (TextbitElement.isBlock(nextNode)
+    && SlateElement.isElement(nextNode)
+    && !!nextNode.children.length
+    && selection.focus.path[0] !== nextPoint.path[0]
+    && Object.prototype.hasOwnProperty.call(nextChildNode, 'text')) {
+    return {
+      edge: getEdge(key),
+      path: [nextPoint.path[0]]
+    }
+  }
+}
+
+function getNextPoint(editor: Editor, selection: BaseRange, key: string) {
+  if (key === 'ArrowRight') {
+    return Editor.after(editor, selection.focus)
+  } else if (key === 'ArrowDown') {
+    return Editor.after(editor, selection)
+  } else if (key === 'ArrowLeft') {
+    return Editor.before(editor, selection.focus)
+  } else if (key === 'ArrowUp') {
+    return Editor.before(editor, selection)
+  }
+}
+
+function getEdge(key: string) {
+  if (key === 'ArrowRight') {
+    return 'start'
+  } else if (key === 'ArrowDown') {
+    return 'start'
+  } else if (key === 'ArrowLeft') {
+    return 'end'
+  } else {
+    return 'end'
   }
 }

--- a/lib/components/TextbitEditable/with/withDeletionManagement.ts
+++ b/lib/components/TextbitEditable/with/withDeletionManagement.ts
@@ -19,6 +19,15 @@ export const withDeletionManagement = (editor: Editor) => {
       const [node, path] = entry
       const string = Node.string(node)
 
+      // If we are at offset 0 in the first child of a block node we
+      // do not allow backspace at all.
+      const firstTextEntry = Editor.first(editor, path)
+      if (firstTextEntry
+        && Path.equals(selection.focus.path, firstTextEntry[1])
+        && selection.focus.offset === 0) {
+        return
+      }
+
       // If we are on the first node in the document and the node is empty we should
       // delete the node instead of a following block node. Necessary to be able to
       // delete an empty start line first in the document. Allowing backspace to do

--- a/lib/components/TextbitEditable/with/withDeletionManagement.ts
+++ b/lib/components/TextbitEditable/with/withDeletionManagement.ts
@@ -1,0 +1,118 @@
+import { Editor, Element, Node, Path, Range, Text, Transforms } from 'slate'
+
+export const withDeletionManagement = (editor: Editor) => {
+  const { deleteBackward, deleteForward } = editor
+
+  editor.deleteBackward = (unit) => {
+    const { selection } = editor
+
+    if (selection && isAtStartOfTopLevelNode(editor)) {
+      const [entry] = Editor.nodes(editor, {
+        match: (n) => Element.isElement(n) && Editor.isBlock(editor, n),
+        at: selection
+      })
+
+      if (!entry) {
+        return deleteBackward(unit)
+      }
+
+      const [node, path] = entry
+      const string = Node.string(node)
+
+      // If we are on the first node in the document and the node is empty we should
+      // delete the node instead of a following block node. Necessary to be able to
+      // delete an empty start line first in the document. Allowing backspace to do
+      // this as Mac users don't have a DEl button.
+      if (!string.length && path[0] === 0) {
+        Transforms.removeNodes(editor, { at: path })
+        return
+      }
+
+      // If we're last in the document and the node is empty, delete the current
+      // node. This differs from elsewhere in the document where we slate rather
+      // delete the previous or joins nodes. This is necessary to be able to delete
+      // an empty last line.
+      const nextPath = Path.next(path)
+      if (!string.length && nextPath[0] >= editor.children.length) {
+        Transforms.removeNodes(editor, { at: path })
+        return
+      }
+
+      // If the previous node is a block node we want to remove the whole block
+      // node instead of moving inside.
+      const prevPath = Path.previous(path)
+      const prevEntry = Editor.node(editor, prevPath)
+      if (prevEntry) {
+        const [prevNode] = prevEntry
+        if (Element.isElement(prevNode) && prevNode.class === 'block') {
+          Transforms.removeNodes(editor, { at: prevPath })
+          return
+        }
+      }
+    }
+
+    deleteBackward(unit)
+  }
+
+  editor.deleteForward = (unit) => {
+    const { selection } = editor
+
+    if (selection && isAtEndOfTopLevelNode(editor)) {
+      const [entry] = Editor.nodes(editor, {
+        match: (n) => Element.isElement(n) && Editor.isBlock(editor, n),
+        at: selection
+      })
+
+      if (!entry) {
+        return deleteForward(unit)
+      }
+
+      const [node, path] = entry
+      const string = Node.string(node)
+
+      // If we are on the first node in the document and the node is empty we should
+      // delete the node instead of a following block node. Necessary to be able to
+      // delete an empty start line first in the document.
+      if (!string.length && path[0] === 0) {
+        Transforms.removeNodes(editor, { at: path })
+        return
+      }
+
+      if (path[0] < editor.children.length - 1) {
+        const [nextNode, nextPath] = Editor.node(editor, [path[0] + 1])
+        if (Element.isElement(nextNode) && nextNode.class === 'block') {
+          Transforms.removeNodes(editor, { at: nextPath })
+          return
+        }
+      }
+    }
+
+    deleteForward(unit)
+  }
+
+  return editor
+}
+
+function isAtStartOfTopLevelNode(editor: Editor) {
+  const { selection } = editor
+  if (!selection || !Range.isCollapsed(selection)) return false
+
+  const [node, path] = Editor.node(editor, selection)
+  if (!Text.isText(node)) return false
+
+  const topLevelPath = [path[0]]
+  const firstText = Editor.first(editor, topLevelPath)
+  return Editor.isStart(editor, selection.anchor, firstText?.[1] ?? path)
+}
+
+function isAtEndOfTopLevelNode(editor: Editor) {
+  const { selection } = editor
+  if (!selection || !Range.isCollapsed(selection)) return false
+
+  const [node, path] = Editor.node(editor, selection)
+  if (!Text.isText(node)) return false
+
+  const topLevelPath = [path[0]]
+  const lastText = Editor.last(editor, topLevelPath)
+  return Editor.isEnd(editor, selection.anchor, lastText?.[1] ?? path)
+}

--- a/lib/components/TextbitEditable/with/withDeletionManagement.ts
+++ b/lib/components/TextbitEditable/with/withDeletionManagement.ts
@@ -1,4 +1,5 @@
 import { Editor, Element, Node, Path, Range, Text, Transforms } from 'slate'
+import { TextbitElement } from '../../../lib'
 
 export const withDeletionManagement = (editor: Editor) => {
   const { deleteBackward, deleteForward } = editor
@@ -19,10 +20,11 @@ export const withDeletionManagement = (editor: Editor) => {
       const [node, path] = entry
       const string = Node.string(node)
 
-      // If we are at offset 0 in the first child of a block node we
+      // If we are at offset 0 in the first text child of a block node we
       // do not allow backspace at all.
       const firstTextEntry = Editor.first(editor, path)
       if (firstTextEntry
+        && TextbitElement.isBlock(node)
         && Path.equals(selection.focus.path, firstTextEntry[1])
         && selection.focus.offset === 0) {
         return

--- a/lib/lib/textbit-element.ts
+++ b/lib/lib/textbit-element.ts
@@ -7,6 +7,7 @@ import {
 
 interface TextbitElementInterface extends ElementInterface {
   isBlock: (value: unknown) => value is Ancestor
+  /** @deprecated */
   isTextblock: (value: unknown) => value is SlateElement
   isText: (value: unknown) => value is SlateElement
   isVoid: (value: unknown) => value is SlateElement
@@ -25,6 +26,7 @@ export const TextbitElement: TextbitElementInterface = {
     return SlateElement.isAncestor(value) && SlateElement.isElement(value) && value.class === 'block'
   },
 
+  /** @deprecated */
   isTextblock: (value: unknown): value is SlateElement => {
     return SlateElement.isElement(value) && value.class === 'textblock'
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import './toolmenu.css'
 import './toolbox.css'
 import './spelling.css'
 import './contextmenu.css'
+import './app.css'
 
 const initialValue: Descendant[] = [
   {
@@ -270,7 +271,7 @@ function Editor({ initialValue }: { initialValue: Descendant[] }) {
         {characters}
       </div>
 
-      <div tabIndex={-1} style={{ flex: '1', display: 'flex', flexDirection: 'column', maxHeight: '150px', overflow: 'scroll' }}>
+      <div tabIndex={-1} style={{ flex: '1', display: 'flex', flexDirection: 'column', maxHeight: '250px', overflow: 'scroll' }}>
         <Textbit.Editable
           value={value}
           onChange={(value) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,12 +83,12 @@ const initialValue: Descendant[] = [
       {
         type: 'core/codeblock/title',
         class: 'text',
-        children: [{ text: '' }]
+        children: [{ text: 'Title' }]
       },
       {
         type: 'core/codeblock/body',
         class: 'text',
-        children: [{ text: '' }]
+        children: [{ text: 'Body' }]
       }
     ]
   },

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,13 @@
+div[role="textbox"] {
+  margin: 5px 10px;
+}
+
+div:focus {
+  outline-color: transparent;
+}
+
+div[data-state="selected"] {
+  outline: rgba(0, 123, 255, .5) solid 2px;
+  outline-offset: 2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
Did not manage to create top level block node selections without too many caveats and edge cases.
Instead improved editing around top level block elements.

1. Delete an empty first line in the document with delete or backspace (to simplify for mac users)
2. Delete an empty last line in the document with backspace
3. Delete a block node with backspace if standing on first pos in text just after the block node if it is not the last line in the document and empty, then see nr 2.
4. Delete a block node with delete if standing on last pos in text just before the block node if position is not on the first line of the document and the line is empty, then see nr 1.
5. Create new paragraph outside of block node if hitting enter last inside last position in last child in a block node.
6. Create new paragraph when hitting enter last on any text type.
7. Improve handling of allowBreak=false constraint.
8. Deprecating textblock nodes as they are no different from block nodes.