### PR TITLE
Feature/support block level selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,19 @@ function ContextMenu() {
 
 ---
 
+### useBlockSelection()
+
+Access the current block-level selection state. Returns `null` when no block selection is active.
+
+```typescript
+const blockSelection = useBlockSelection()
+// Returns: { anchorIndex: number, focusIndex: number } | null
+```
+
+The selected range spans from `Math.min(anchorIndex, focusIndex)` to `Math.max(anchorIndex, focusIndex)` inclusive, referencing top-level block indices in the editor. See [Block Selection](#block-selection-shiftarrow) for details on how block selection is initiated and controlled.
+
+---
+
 ### useSelectionBounds()
 
 Get the current selection's bounding rectangle.
@@ -1597,6 +1610,32 @@ Up/Down moves the indicator to the neighbouring top-level block, preserving the 
 | Backspace | Removes the block or character behind the caret position |
 | Delete | Removes the block ahead of the caret position |
 | Printable character | Inserts a new text block and types the character into it |
+
+### Block Selection (Shift+Arrow)
+
+While the block caret is active, holding Shift and pressing any arrow key initiates block-level selection. Entire top-level blocks are selected rather than individual text ranges.
+
+#### Entry from Block Caret
+
+| Caret position | Key | Selects |
+|----------------|-----|---------|
+| Before block X | Shift+Up/Left | Block above (X−1) |
+| Before block X | Shift+Down/Right | Current block (X) |
+| After block X | Shift+Up/Left | Current block (X) |
+| After block X | Shift+Down/Right | Block below (X+1) |
+
+#### While Block Selection Is Active
+
+| Key | Behavior |
+|-----|----------|
+| Shift+Arrow | Extends or contracts the selection by one block |
+| Arrow (no shift) | Collapses selection and places cursor at the edge of the first/last selected block |
+| Backspace / Delete | Removes all selected blocks |
+| Cmd/Ctrl+C | Copies selected blocks |
+| Cmd/Ctrl+X | Cuts selected blocks |
+| Mouse click | Clears block selection |
+
+Selected blocks receive a `data-block-selected` attribute and a `.tb-block-selected` overlay element for styling. Text content within the selection also shows the native browser highlight. The `useBlockSelection()` hook exposes the current selection state (`anchorIndex` / `focusIndex`) to consumer components.
 
 ---
 

--- a/lib/components/ContextTools/Menu.tsx
+++ b/lib/components/ContextTools/Menu.tsx
@@ -4,6 +4,7 @@ import { useFocused, useSlateStatic } from 'slate-react'
 import { Editor } from 'slate'
 import { TextbitElement } from '../../utils/textbit-element'
 import { useSelectionBounds } from '../../hooks/useSelectionBounds'
+import { useBlockSelection } from '../../hooks/useBlockSelection'
 import { ContextMenuHintsContext } from '../ContextMenu/ContextMenuHintsContext'
 import type { SelectionBounds } from '../../contexts/SelectionBoundsContext'
 
@@ -26,6 +27,7 @@ function Popover({ children, className }: {
   const editor = useSlateStatic()
   const bounds = useSelectionBounds()
   const focused = useFocused()
+  const blockSelection = useBlockSelection()
   const ref = useRef<HTMLDivElement>(null)
   const contextMenuHintsContext = useContext(ContextMenuHintsContext)
   const isContextMenuOpen = contextMenuHintsContext?.menu != null
@@ -56,12 +58,12 @@ function Popover({ children, className }: {
       showMenu = !!node
     }
 
-    if (showMenu && !isContextMenuOpen) {
+    if (showMenu && !isContextMenuOpen && !blockSelection) {
       setVisibility(true)
     } else {
       setVisibility(false)
     }
-  }, [editor, bounds, focused, setVisibility, isContextMenuOpen])
+  }, [editor, bounds, focused, setVisibility, isContextMenuOpen, blockSelection])
 
   const move = useCallback((selectionBounds: SelectionBounds) => {
     if (!focused) {

--- a/lib/components/Element/ParentElement.tsx
+++ b/lib/components/Element/ParentElement.tsx
@@ -2,6 +2,7 @@ import { useSelected, useSlateStatic, type RenderElementProps } from 'slate-reac
 import { Droppable } from './Droppable'
 import type { ComponentEntry } from '../../types'
 import { useAdjacentBlock } from '../../hooks/useAdjacentBlock'
+import { useBlockSelection } from '../../hooks/useBlockSelection'
 import { CSSProperties } from 'react'
 
 interface ParentElementProps extends RenderElementProps {
@@ -19,7 +20,18 @@ export function ParentElement(renderProps: ParentElementProps) {
   const active = useSelected() // Whether cursor is inside block
   const editor = useSlateStatic()
   const adjacentBlock = useAdjacentBlock()
+  const blockSelection = useBlockSelection()
   const { element, attributes, entry } = renderProps
+
+  // Block-level selection: check if this element is within the selected range
+  const isBlockSelected = (() => {
+    if (!blockSelection) return false
+    const myIndex = editor.children.findIndex(c => c === element)
+    if (myIndex === -1) return false
+    const lo = Math.min(blockSelection.anchorIndex, blockSelection.focusIndex)
+    const hi = Math.max(blockSelection.anchorIndex, blockSelection.focusIndex)
+    return myIndex >= lo && myIndex <= hi
+  })()
 
   const adjacentState: 'before' | 'after' | null = adjacentBlock && adjacentBlock.blockId === element.id
     ? adjacentBlock.direction
@@ -56,6 +68,7 @@ export function ParentElement(renderProps: ParentElementProps) {
         lang={renderProps.element.lang || editor.lang}
         data-id={element.id}
         data-state={dataState}
+        {...(isBlockSelected ? { 'data-block-selected': '' } : {})}
         className={`${element.class} ${element.type} ${entry.class} relative group`}
         style={{ position: 'relative' }}
         {...attributes}
@@ -69,6 +82,20 @@ export function ParentElement(renderProps: ParentElementProps) {
               position: 'absolute',
               inset: 0,
               pointerEvents: 'none',
+            }}
+          />
+        )}
+        {isBlockSelected && (
+          <div
+            contentEditable={false}
+            className='tb-block-selected'
+            style={{
+              position: 'absolute',
+              inset: -2,
+              pointerEvents: 'none',
+              outline: '2px solid Highlight',
+              outlineOffset: '2px',
+              borderRadius: 'var(--tb-focus-ring-radius, 5px)',
             }}
           />
         )}

--- a/lib/components/Element/ParentElement.tsx
+++ b/lib/components/Element/ParentElement.tsx
@@ -70,7 +70,7 @@ export function ParentElement(renderProps: ParentElementProps) {
         data-state={dataState}
         {...(isBlockSelected ? { 'data-block-selected': '' } : {})}
         className={`${element.class} ${element.type} ${entry.class} relative group`}
-        style={{ position: 'relative' }}
+        style={{ position: 'relative', ...(isBlockSelected ? { userSelect: 'none' } : {}) }}
         {...attributes}
       >
         <entry.component {...renderProps} editor={editor} />

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -253,10 +253,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
 
   return (
     <>
-      {blockSelection && (
-        <style>{`[data-block-selected] *::selection { background: transparent; color: inherit; }`}</style>
-      )}
-      <BlockSelectionProvider value={blockSelection}>
+<BlockSelectionProvider value={blockSelection}>
         <AdjacentBlockProvider value={adjacentBlock}>
           <DragStateProvider>
             <PresenceOverlay isCollaborative={collaborative}>

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -14,6 +14,8 @@ import type { SpellcheckLookupTable } from '../../types'
 import { SelectionBoundsDetails } from '../SelectionBoundsDetails'
 import { type AdjacentBlockState } from '../../contexts/AdjacentBlockContext'
 import { AdjacentBlockProvider } from '../../contexts/AdjacentBlockProvider'
+import { type BlockSelectionState } from '../../contexts/BlockSelectionContext'
+import { BlockSelectionProvider } from '../../contexts/BlockSelectionProvider'
 import { handleOnKeyDown } from './handleOnKeyDown/handleOnKeyDown'
 
 interface TextbitEditableProps {
@@ -35,6 +37,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
   const handleContextMenu = useContextMenu()
   const [spellingLookupTable, setSpellingLookupTable] = useState<SpellcheckLookupTable>(new Map())
   const [adjacentBlock, setAdjacentBlock] = useState<AdjacentBlockState | null>(null)
+  const [blockSelection, setBlockSelection] = useState<BlockSelectionState | null>(null)
   const { onFocus, autoFocus = false } = props
 
   // Track mounted state
@@ -115,8 +118,8 @@ export function TextbitEditable(props: TextbitEditableProps) {
   }, [editor, components, placeholders, placeholder, spellingLookupTable])
 
   const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-    handleOnKeyDown(editor, actions, event, adjacentBlock, setAdjacentBlock)
-  }, [editor, actions, adjacentBlock, setAdjacentBlock])
+    handleOnKeyDown(editor, actions, event, adjacentBlock, setAdjacentBlock, blockSelection, setBlockSelection)
+  }, [editor, actions, adjacentBlock, setAdjacentBlock, blockSelection, setBlockSelection])
 
   /**
    * Fixefox does not set the caret position correctly when clicking
@@ -160,13 +163,19 @@ export function TextbitEditable(props: TextbitEditableProps) {
         Transforms.select(editor, Editor.end(editor, [i]))
       }
       setAdjacentBlock({ blockId: block.id, direction })
+      if (blockSelection) {
+        setBlockSelection(null)
+      }
 
       return
     }
 
-    // Default: clear adjacent block state on any other click
+    // Default: clear adjacent block and block selection state on any other click
     if (adjacentBlock) {
       setAdjacentBlock(null)
+    }
+    if (blockSelection) {
+      setBlockSelection(null)
     }
 
     // We only need to handle this for Firefox (Gecko rendering engine)
@@ -180,10 +189,11 @@ export function TextbitEditable(props: TextbitEditableProps) {
         Transforms.select(editor, range)
       }
     }
-  }, [editor, isFocused, adjacentBlock, setAdjacentBlock])
+  }, [editor, isFocused, adjacentBlock, setAdjacentBlock, blockSelection, setBlockSelection])
 
   return (
     <>
+      <BlockSelectionProvider value={blockSelection}>
       <AdjacentBlockProvider value={adjacentBlock}>
         <DragStateProvider>
           <PresenceOverlay isCollaborative={collaborative}>
@@ -198,7 +208,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
               onKeyDown={onKeyDown}
               decorate={decorate}
               className={props.className}
-              style={adjacentBlock
+              style={adjacentBlock || blockSelection
                 ? { ...props.style, caretColor: 'transparent' }
                 : props.style
               }
@@ -212,6 +222,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
           </PresenceOverlay>
         </DragStateProvider>
       </AdjacentBlockProvider>
+      </BlockSelectionProvider>
 
       {verbose && <SelectionBoundsDetails />}
     </>

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -18,6 +18,7 @@ import { type BlockSelectionState } from '../../contexts/BlockSelectionContext'
 import { BlockSelectionProvider } from '../../contexts/BlockSelectionProvider'
 import { handleOnKeyDown } from './handleOnKeyDown/handleOnKeyDown'
 import { trimWhitespace } from '../../utils/trimWhitespace'
+import { prepareBlockAwarePaste } from '../../utils/blockAwarePaste'
 
 interface TextbitEditableProps {
   autoFocus?: boolean | 'start' | 'end'
@@ -145,6 +146,42 @@ export function TextbitEditable(props: TextbitEditableProps) {
   }, [editor, actions, adjacentBlock, setAdjacentBlock, blockSelection, setBlockSelection])
 
   /**
+   * Redirect paste when block caret or block selection is active so the
+   * clipboard content lands adjacent to (or replaces) the affected
+   * block(s), rather than inside the block the hidden Slate selection
+   * happens to point at. See utils/blockAwarePaste.ts for details.
+   */
+  const onPaste = useCallback((event: React.ClipboardEvent<HTMLDivElement>) => {
+    if (!adjacentBlock && !blockSelection) {
+      return
+    }
+
+    const data = event.clipboardData
+    if (!data) {
+      return
+    }
+
+    const result = prepareBlockAwarePaste(editor, data, adjacentBlock, blockSelection)
+
+    if (result === 'unhandled') {
+      return
+    }
+
+    // Clear block-level states; from here on the editor is in a normal
+    // collapsed-selection state.
+    if (adjacentBlock) setAdjacentBlock(null)
+    if (blockSelection) setBlockSelection(null)
+
+    if (result === 'handled') {
+      // Slate fragment was inserted directly — stop slate-react from also
+      // running its default paste handler.
+      event.preventDefault()
+    }
+    // For 'prepared' we leave the event alone so slate-react's default
+    // paste handler populates the placeholder via editor.insertData.
+  }, [editor, adjacentBlock, blockSelection, setAdjacentBlock, setBlockSelection])
+
+  /**
    * Fixefox does not set the caret position correctly when clicking
    * in an unfocused Editable area. If the gecko rendering engine is
    * detected we help the user by setting the caret position.
@@ -232,6 +269,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
                 onFocus={handleFocus}
                 onBlur={handleBlur}
                 onKeyDown={onKeyDown}
+                onPaste={onPaste}
                 decorate={decorate}
                 className={props.className}
                 style={adjacentBlock || blockSelection

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -194,34 +194,34 @@ export function TextbitEditable(props: TextbitEditableProps) {
   return (
     <>
       <BlockSelectionProvider value={blockSelection}>
-      <AdjacentBlockProvider value={adjacentBlock}>
-        <DragStateProvider>
-          <PresenceOverlay isCollaborative={collaborative}>
-            <Editable
-              autoFocus={!!autoFocus}
-              data-state={isFocused ? 'focused' : ''}
-              readOnly={readOnly}
-              renderElement={renderElement}
-              renderLeaf={renderLeaf}
-              onFocus={handleFocus}
-              onBlur={props.onBlur}
-              onKeyDown={onKeyDown}
-              decorate={decorate}
-              className={props.className}
-              style={adjacentBlock || blockSelection
-                ? { ...props.style, caretColor: 'transparent' }
-                : props.style
-              }
-              spellCheck={false}
-              dir={dir}
-              onContextMenu={handleContextMenu}
-              onMouseDown={onMouseDown}
-              aria-label={props['aria-label']}
-            />
-            {props.children}
-          </PresenceOverlay>
-        </DragStateProvider>
-      </AdjacentBlockProvider>
+        <AdjacentBlockProvider value={adjacentBlock}>
+          <DragStateProvider>
+            <PresenceOverlay isCollaborative={collaborative}>
+              <Editable
+                autoFocus={!!autoFocus}
+                data-state={isFocused ? 'focused' : ''}
+                readOnly={readOnly}
+                renderElement={renderElement}
+                renderLeaf={renderLeaf}
+                onFocus={handleFocus}
+                onBlur={props.onBlur}
+                onKeyDown={onKeyDown}
+                decorate={decorate}
+                className={props.className}
+                style={adjacentBlock || blockSelection
+                  ? { ...props.style, caretColor: 'transparent' }
+                  : props.style
+                }
+                spellCheck={false}
+                dir={dir}
+                onContextMenu={handleContextMenu}
+                onMouseDown={onMouseDown}
+                aria-label={props['aria-label']}
+              />
+              {props.children}
+            </PresenceOverlay>
+          </DragStateProvider>
+        </AdjacentBlockProvider>
       </BlockSelectionProvider>
 
       {verbose && <SelectionBoundsDetails />}

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -216,6 +216,9 @@ export function TextbitEditable(props: TextbitEditableProps) {
 
   return (
     <>
+      {blockSelection && (
+        <style>{`[data-block-selected] *::selection { background: transparent; color: inherit; }`}</style>
+      )}
       <BlockSelectionProvider value={blockSelection}>
         <AdjacentBlockProvider value={adjacentBlock}>
           <DragStateProvider>

--- a/lib/components/TextbitEditable/handleOnKeyDown/blockSelectionHandler.ts
+++ b/lib/components/TextbitEditable/handleOnKeyDown/blockSelectionHandler.ts
@@ -196,6 +196,14 @@ export function handleBlockSelectionKeyDown(
     return
   }
 
+  // ── Cmd/Ctrl+V — let the native paste event fire ──────────────────────
+  // The onPaste handler on TextbitEditable consumes the block selection
+  // state, removes the selected blocks and inserts the clipboard content
+  // in their place. Do NOT preventDefault here.
+  if (hasMod && key === 'v') {
+    return
+  }
+
   // ── All other keys: consume, no-op ────────────────────────────────────
   event.preventDefault()
 }

--- a/lib/components/TextbitEditable/handleOnKeyDown/blockSelectionHandler.ts
+++ b/lib/components/TextbitEditable/handleOnKeyDown/blockSelectionHandler.ts
@@ -1,0 +1,201 @@
+import { Editor, Element, Transforms } from 'slate'
+import type { AdjacentBlockState } from '../../../contexts/AdjacentBlockContext'
+import type { BlockSelectionState } from '../../../contexts/BlockSelectionContext'
+import { resolveTargetIndex, enterBlockFromStart, enterBlockFromEnd } from './blockUtils'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Set the real Slate selection to span all blocks in the block-selection range.
+ * This gives us native browser text highlighting and native clipboard copy.
+ */
+export function syncSlateSelection(editor: Editor, bs: BlockSelectionState): void {
+  const lo = Math.min(bs.anchorIndex, bs.focusIndex)
+  const hi = Math.max(bs.anchorIndex, bs.focusIndex)
+  Transforms.select(editor, {
+    anchor: Editor.start(editor, [lo]),
+    focus: Editor.end(editor, [hi])
+  })
+}
+
+/**
+ * Remove all blocks in the selection range, then place the cursor at
+ * the appropriate position in the remaining document.
+ */
+function deleteSelectedBlocks(
+  editor: Editor,
+  blockSelection: BlockSelectionState,
+  setBlockSelection: (state: BlockSelectionState | null) => void
+): void {
+  const lo = Math.min(blockSelection.anchorIndex, blockSelection.focusIndex)
+  const hi = Math.max(blockSelection.anchorIndex, blockSelection.focusIndex)
+
+  Editor.withoutNormalizing(editor, () => {
+    for (let i = hi; i >= lo; i--) {
+      Transforms.removeNodes(editor, { at: [i] })
+    }
+  })
+
+  setBlockSelection(null)
+
+  // Place cursor after deletion (Slate normalizer ensures ≥1 child)
+  if (lo < editor.children.length) {
+    Transforms.select(editor, Editor.start(editor, [lo]))
+  } else if (editor.children.length > 0) {
+    Transforms.select(editor, Editor.end(editor, [editor.children.length - 1]))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry from adjacent caret
+// ---------------------------------------------------------------------------
+
+/**
+ * Called when `adjacentBlock` is active, `event.shiftKey` is true,
+ * and key is ArrowUp/Down/Left/Right.
+ *
+ * Left behaves like Up, Right behaves like Down.
+ * Returns the initial BlockSelectionState, or null if out of bounds.
+ */
+export function enterBlockSelectionFromAdjacentCaret(
+  editor: Editor,
+  event: React.KeyboardEvent<HTMLDivElement>,
+  adjacentBlock: AdjacentBlockState
+): BlockSelectionState | null {
+  const targetIndex = resolveTargetIndex(editor, adjacentBlock)
+  if (targetIndex === -1) return null
+
+  const goingForward = event.key === 'ArrowDown' || event.key === 'ArrowRight'
+  const { direction } = adjacentBlock
+
+  // Entry rules:
+  // before + Up/Left    → select block above (targetIndex - 1)
+  // before + Down/Right → select current block (targetIndex)
+  // after  + Up/Left    → select current block (targetIndex)
+  // after  + Down/Right → select block below (targetIndex + 1)
+  let selectIndex: number
+
+  if (direction === 'before' && !goingForward) {
+    selectIndex = targetIndex - 1
+  } else if (direction === 'before' && goingForward) {
+    selectIndex = targetIndex
+  } else if (direction === 'after' && !goingForward) {
+    selectIndex = targetIndex
+  } else {
+    // direction === 'after' && goingForward
+    selectIndex = targetIndex + 1
+  }
+
+  // Bounds check
+  if (selectIndex < 0 || selectIndex >= editor.children.length) {
+    return null
+  }
+
+  const state = { anchorIndex: selectIndex, focusIndex: selectIndex }
+  syncSlateSelection(editor, state)
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Key handling while block selection is active
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles all key events while block selection is active.
+ *
+ * - Shift+Arrow: extend selection
+ * - Unshifted arrow: collapse selection and exit
+ * - Delete/Backspace: remove selected blocks
+ * - Cmd/Ctrl+C: pass through for native copy
+ * - Cmd/Ctrl+X: copy then delete blocks
+ * - All other keys: consumed (no-op)
+ */
+export function handleBlockSelectionKeyDown(
+  editor: Editor,
+  event: React.KeyboardEvent<HTMLDivElement>,
+  blockSelection: BlockSelectionState,
+  setBlockSelection: (state: BlockSelectionState | null) => void,
+  setAdjacentBlock: (state: AdjacentBlockState | null) => void
+): void {
+  const key = event.key
+  const isArrow = key === 'ArrowUp' || key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight'
+  const hasMod = event.metaKey || event.ctrlKey
+
+  // ── Shift+Arrow — extend selection ────────────────────────────────────
+  if (event.shiftKey && isArrow) {
+    event.preventDefault()
+    const goingForward = key === 'ArrowDown' || key === 'ArrowRight'
+    const lastIndex = editor.children.length - 1
+    const newFocus = goingForward
+      ? Math.min(blockSelection.focusIndex + 1, lastIndex)
+      : Math.max(blockSelection.focusIndex - 1, 0)
+    const newState = { ...blockSelection, focusIndex: newFocus }
+    setBlockSelection(newState)
+    syncSlateSelection(editor, newState)
+    return
+  }
+
+  // ── Unshifted arrow — collapse selection ──────────────────────────────
+  if (isArrow && !event.shiftKey) {
+    event.preventDefault()
+
+    const lo = Math.min(blockSelection.anchorIndex, blockSelection.focusIndex)
+    const hi = Math.max(blockSelection.anchorIndex, blockSelection.focusIndex)
+
+    // Up/Left → start of first selected block
+    // Down/Right → end of last selected block
+    const goingUp = key === 'ArrowUp' || key === 'ArrowLeft'
+    const targetIndex = goingUp ? lo : hi
+    const targetBlock = editor.children[targetIndex]
+
+    setBlockSelection(null)
+
+    if (Element.isElement(targetBlock) && targetBlock.class !== 'text') {
+      // Non-text block: enter adjacent caret mode
+      if (goingUp) {
+        enterBlockFromStart(editor, [targetIndex], targetBlock)
+        setAdjacentBlock({ blockId: targetBlock.id, direction: 'before' })
+      } else {
+        enterBlockFromEnd(editor, [targetIndex], targetBlock)
+        setAdjacentBlock({ blockId: targetBlock.id, direction: 'after' })
+      }
+    } else {
+      // Text block: place normal cursor
+      if (goingUp) {
+        Transforms.select(editor, Editor.start(editor, [targetIndex]))
+      } else {
+        Transforms.select(editor, Editor.end(editor, [targetIndex]))
+      }
+    }
+    return
+  }
+
+  // ── Delete / Backspace — remove selected blocks ───────────────────────
+  if (key === 'Backspace' || key === 'Delete') {
+    event.preventDefault()
+    deleteSelectedBlocks(editor, blockSelection, setBlockSelection)
+    return
+  }
+
+  // ── Cmd/Ctrl+C — let native copy pass through ────────────────────────
+  // The Slate selection spans the selected blocks, so the browser/Slate
+  // copy handler writes the correct fragment to the clipboard.
+  if (hasMod && key === 'c') {
+    return
+  }
+
+  // ── Cmd/Ctrl+X — cut: copy then delete ────────────────────────────────
+  if (hasMod && key === 'x') {
+    // Trigger a synchronous copy via the deprecated-but-universal
+    // execCommand; Slate's onCopy handler serialises the fragment.
+    document.execCommand('copy')
+    event.preventDefault()
+    deleteSelectedBlocks(editor, blockSelection, setBlockSelection)
+    return
+  }
+
+  // ── All other keys: consume, no-op ────────────────────────────────────
+  event.preventDefault()
+}

--- a/lib/components/TextbitEditable/handleOnKeyDown/handleOnKeyDown.ts
+++ b/lib/components/TextbitEditable/handleOnKeyDown/handleOnKeyDown.ts
@@ -2,9 +2,11 @@ import { Editor, Element, Range, Transforms } from 'slate'
 import type { PluginRegistryAction } from '../../../contexts/PluginRegistry/lib/types'
 import { toggleLeaf } from '../../../utils/toggleLeaf'
 import type { AdjacentBlockState } from '../../../contexts/AdjacentBlockContext'
+import type { BlockSelectionState } from '../../../contexts/BlockSelectionContext'
 import { handleArrowWithAdjacentBlock, handleArrowNoAdjacentBlock, handleVerticalArrowWithAdjacentBlock } from './arrowHandlers'
 import { handleNonArrowWithAdjacentBlock } from './nonArrowHandler'
 import { isAtAccessibleEnd, isAtAccessibleStart } from './blockUtils'
+import { enterBlockSelectionFromAdjacentCaret, handleBlockSelectionKeyDown } from './blockSelectionHandler'
 
 /*
  * Match key events to registered actions keyboard shortcuts. Then either
@@ -17,8 +19,28 @@ export function handleOnKeyDown(
   actions: PluginRegistryAction[],
   event: React.KeyboardEvent<HTMLDivElement>,
   adjacentBlock: AdjacentBlockState | null,
-  setAdjacentBlock: (state: AdjacentBlockState | null) => void
+  setAdjacentBlock: (state: AdjacentBlockState | null) => void,
+  blockSelection: BlockSelectionState | null,
+  setBlockSelection: (state: BlockSelectionState | null) => void
 ) {
+  // 1. Block selection active — delegate all keys to block selection handler
+  if (blockSelection) {
+    handleBlockSelectionKeyDown(editor, event, blockSelection, setBlockSelection, setAdjacentBlock)
+    return
+  }
+
+  // 2. Adjacent caret + Shift+Arrow — enter block selection mode
+  if (adjacentBlock && event.shiftKey
+    && (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'ArrowLeft' || event.key === 'ArrowRight')) {
+    const newSelection = enterBlockSelectionFromAdjacentCaret(editor, event, adjacentBlock)
+    if (newSelection) {
+      event.preventDefault()
+      setAdjacentBlock(null)
+      setBlockSelection(newSelection)
+    }
+    return
+  }
+
   const key = event.key
   const goingForward = key === 'ArrowRight' // || key === 'ArrowDown'
   const goingBackward = key === 'ArrowLeft' // || key === 'ArrowUp'

--- a/lib/components/TextbitEditable/handleOnKeyDown/nonArrowHandler.ts
+++ b/lib/components/TextbitEditable/handleOnKeyDown/nonArrowHandler.ts
@@ -131,6 +131,13 @@ export function handleNonArrowWithAdjacentBlock(
     return true
   }
 
+  // Cmd/Ctrl+V — let the paste event propagate to the onPaste handler,
+  // which is responsible for redirecting insertion to the correct path
+  // and clearing the adjacent state. Do not preventDefault here.
+  if ((event.metaKey || event.ctrlKey) && event.key === 'v') {
+    return true
+  }
+
   // Printable character: insert a new text element and let the character be typed into it
   if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
     const targetIndex = resolveTargetIndex(editor, adjacentBlock)

--- a/lib/contexts/BlockSelectionContext.tsx
+++ b/lib/contexts/BlockSelectionContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+
+export interface BlockSelectionState {
+  anchorIndex: number  // Fixed end — where selection started
+  focusIndex: number   // Moving end — extends with Shift+Up/Down
+}
+
+export const BlockSelectionContext = createContext<BlockSelectionState | null>(null)

--- a/lib/contexts/BlockSelectionProvider.tsx
+++ b/lib/contexts/BlockSelectionProvider.tsx
@@ -1,0 +1,12 @@
+import { BlockSelectionContext, type BlockSelectionState } from './BlockSelectionContext'
+
+export function BlockSelectionProvider({ value, children }: {
+  value: BlockSelectionState | null
+  children: React.ReactNode
+}) {
+  return (
+    <BlockSelectionContext.Provider value={value}>
+      {children}
+    </BlockSelectionContext.Provider>
+  )
+}

--- a/lib/hooks/useBlockSelection.tsx
+++ b/lib/hooks/useBlockSelection.tsx
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { BlockSelectionContext, type BlockSelectionState } from '../contexts/BlockSelectionContext'
+
+export function useBlockSelection(): BlockSelectionState | null {
+  return useContext(BlockSelectionContext)
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -79,6 +79,7 @@ export { useTextbit } from './hooks/useTextbit'
 export { useContextMenuHints } from './components/ContextMenu/useContextMenuHints'
 export { useSelectionBounds } from './hooks/useSelectionBounds'
 export { useEditor } from './hooks/useEditor'
+export { useBlockSelection } from './hooks/useBlockSelection'
 
 export {
   pipeFromDrop as consumeFileDropEvent,

--- a/lib/utils/blockAwarePaste.ts
+++ b/lib/utils/blockAwarePaste.ts
@@ -1,0 +1,153 @@
+import { Editor, Element, Transforms, type Descendant } from 'slate'
+import type { AdjacentBlockState } from '../contexts/AdjacentBlockContext'
+import type { BlockSelectionState } from '../contexts/BlockSelectionContext'
+
+/**
+ * Result describing how the paste should proceed after block-aware
+ * preparation has run.
+ *
+ * - 'handled'     : the paste was fully inserted (caller must preventDefault
+ *                   to stop slate-react's default paste handler).
+ * - 'prepared'    : an empty placeholder text block has been inserted and
+ *                   selected at the target path. The caller should NOT
+ *                   preventDefault; slate-react's default paste handler will
+ *                   fill the placeholder via editor.insertData.
+ * - 'unhandled'   : neither adjacentBlock nor blockSelection was active, or
+ *                   the target could not be resolved. Normal paste behaviour.
+ */
+export type BlockAwarePasteResult = 'handled' | 'prepared' | 'unhandled'
+
+/**
+ * Prepare and/or execute a paste when the block caret (adjacentBlock) or
+ * block-level selection (blockSelection) is active.
+ *
+ * The real Slate selection while these states are active is kept INSIDE
+ * one of the blocks so that `useSelected()` stays correct. A naïve paste
+ * would therefore insert the clipboard content inside that block, which is
+ * never what the user wants — they expect the pasted content to land
+ * adjacent to (or replacing) the affected block(s).
+ *
+ * Strategy:
+ *   1. Compute the target path on the editor's top level.
+ *   2. If a Slate fragment is available on the clipboard, decode it and
+ *      insert the nodes directly at that path. Types and roles are
+ *      preserved exactly (we bypass editor.insertFragment which would
+ *      otherwise rewrite roles when merging into an empty paragraph).
+ *   3. Otherwise, insert an empty text placeholder at the target path,
+ *      select it, and let Slate's existing paste flow (including
+ *      withInsertHtml + consumer plugins) populate it from HTML / text.
+ *
+ * The caller is responsible for clearing the adjacentBlock / blockSelection
+ * React state after this returns.
+ */
+export function prepareBlockAwarePaste(
+  editor: Editor,
+  data: DataTransfer,
+  adjacentBlock: AdjacentBlockState | null,
+  blockSelection: BlockSelectionState | null
+): BlockAwarePasteResult {
+  if (!adjacentBlock && !blockSelection) {
+    return 'unhandled'
+  }
+
+  const target = resolveTargetIndex(editor, adjacentBlock, blockSelection)
+  if (target === null) {
+    return 'unhandled'
+  }
+
+  const { targetIndex, removeRange } = target
+  const slateFragment = decodeSlateFragment(data)
+
+  if (slateFragment && slateFragment.length > 0) {
+    // Direct insertion — preserves types/roles, no merge behaviour
+    Editor.withoutNormalizing(editor, () => {
+      if (removeRange) {
+        for (let i = removeRange.hi; i >= removeRange.lo; i--) {
+          Transforms.removeNodes(editor, { at: [i] })
+        }
+      }
+      Transforms.insertNodes(editor, slateFragment, { at: [targetIndex] })
+    })
+
+    // Place caret at the end of the last inserted block (user request).
+    // If the last inserted block has no accessible text edge (pure void),
+    // selection is left wherever Slate put it.
+    const lastPath = [targetIndex + slateFragment.length - 1]
+    try {
+      Transforms.select(editor, Editor.end(editor, lastPath))
+    } catch {
+      // Non-text / void: best-effort; leave selection as is.
+    }
+
+    return 'handled'
+  }
+
+  // No Slate fragment on clipboard — prepare a placeholder and let
+  // slate-react's default paste populate it via editor.insertData.
+  Editor.withoutNormalizing(editor, () => {
+    if (removeRange) {
+      for (let i = removeRange.hi; i >= removeRange.lo; i--) {
+        Transforms.removeNodes(editor, { at: [i] })
+      }
+    }
+    const placeholder: Descendant = {
+      id: crypto.randomUUID(),
+      type: 'core/text',
+      class: 'text',
+      properties: {},
+      children: [{ text: '' }]
+    }
+    Transforms.insertNodes(editor, placeholder, { at: [targetIndex], select: true })
+  })
+
+  return 'prepared'
+}
+
+/**
+ * Resolve the top-level path index where new content should be inserted,
+ * plus an optional range of existing blocks to remove.
+ */
+function resolveTargetIndex(
+  editor: Editor,
+  adjacentBlock: AdjacentBlockState | null,
+  blockSelection: BlockSelectionState | null
+): { targetIndex: number; removeRange: { lo: number; hi: number } | null } | null {
+  if (blockSelection) {
+    const lo = Math.min(blockSelection.anchorIndex, blockSelection.focusIndex)
+    const hi = Math.max(blockSelection.anchorIndex, blockSelection.focusIndex)
+    if (lo < 0 || hi >= editor.children.length) return null
+    return { targetIndex: lo, removeRange: { lo, hi } }
+  }
+
+  if (adjacentBlock) {
+    const blockIndex = editor.children.findIndex(
+      (c) => Element.isElement(c) && c.id === adjacentBlock.blockId
+    )
+    if (blockIndex === -1) return null
+    const targetIndex = adjacentBlock.direction === 'before' ? blockIndex : blockIndex + 1
+    return { targetIndex, removeRange: null }
+  }
+
+  return null
+}
+
+/**
+ * Decode the `application/x-slate-fragment` clipboard payload. Slate writes
+ * this as `window.btoa(encodeURIComponent(JSON.stringify(nodes)))`.
+ */
+function decodeSlateFragment(data: DataTransfer): Descendant[] | null {
+  if (!data.types.includes('application/x-slate-fragment')) {
+    return null
+  }
+
+  const encoded = data.getData('application/x-slate-fragment')
+  if (!encoded) return null
+
+  try {
+    const decoded = decodeURIComponent(window.atob(encoded))
+    const parsed = JSON.parse(decoded)
+    return Array.isArray(parsed) ? (parsed as Descendant[]) : null
+  } catch {
+    return null
+  }
+}

--- a/lib/with/withInsertFragment.ts
+++ b/lib/with/withInsertFragment.ts
@@ -1,4 +1,4 @@
-import { Editor, Node, Range, Path, Element, Point } from 'slate'
+import { Editor, Node, Range, Path, Element, Point, Transforms } from 'slate'
 import { TextbitElement } from '../main'
 
 /**
@@ -27,8 +27,48 @@ export function withInsertFragment(editor: Editor) {
       return
     }
 
-    // Not applicable unless all fragments are text nodes
+    // When the fragment contains non-text blocks and the cursor is inside a
+    // top-level text paragraph, split the paragraph at the cursor and insert
+    // the block nodes as top-level siblings. This prevents Slate's default
+    // insertFragment from unwrapping block structures into inline context
+    // (which destroys void elements and their properties).
     if (!fragment.every(TextbitElement.isText)) {
+      const anchor = selection.anchor
+      const focus = selection.focus
+
+      if (anchor.path[0] === focus.path[0]) {
+        const topIndex = anchor.path[0]
+        const topNode = editor.children[topIndex]
+
+        if (Element.isElement(topNode) && topNode.class === 'text') {
+          if (!Range.isCollapsed(selection)) {
+            Transforms.delete(editor)
+          }
+
+          const point = editor.selection!.anchor
+          const isAtStart = Point.equals(point, Editor.start(editor, [topIndex]))
+          const isAtEnd = Point.equals(point, Editor.end(editor, [topIndex]))
+          const needsSplit = !isAtStart && !isAtEnd
+          const insertAt = isAtStart ? topIndex : topIndex + 1
+
+          Editor.withoutNormalizing(editor, () => {
+            if (needsSplit) {
+              Transforms.splitNodes(editor, {
+                at: point,
+                match: (_, p) => p.length === 1
+              })
+            }
+
+            for (let i = 0; i < fragment.length; i++) {
+              Transforms.insertNodes(editor, fragment[i], { at: [insertAt + i] })
+            }
+          })
+
+          Transforms.select(editor, Editor.end(editor, [insertAt + fragment.length - 1]))
+          return
+        }
+      }
+
       insertFragment(fragment, options)
       return
     }

--- a/lib/with/withUniqueIds.ts
+++ b/lib/with/withUniqueIds.ts
@@ -1,8 +1,10 @@
-import { Editor, Node, Element } from 'slate'
+import { Editor, Element, type Node } from 'slate'
 
 /*
  * If a node is in any way inserted or created it must be assigned a unique id.
- * If copied, or split the inserted node must have its id overridden.
+ * If copied, or split, the inserted node — and every nested element inside it —
+ * must have its id overridden if it collides with any existing id in the editor
+ * or with another id appearing earlier in the same subtree.
  */
 
 type NodeWithId = Partial<Node> & {
@@ -14,16 +16,9 @@ export function withUniqueIds(editor: Editor) {
 
   editor.apply = (operation) => {
     if (operation.type === 'insert_node') {
-      const node = operation.node
-
-      if (Element.isElement(node) && (!node.id || idExists(editor, node))) {
-        const nodeWithNewId = structuredClone(node)
-        nodeWithNewId.id = crypto.randomUUID()
-
-        return apply({
-          ...operation,
-          node: nodeWithNewId
-        })
+      const rewritten = rewriteSubtreeIds(editor, operation.node)
+      if (rewritten) {
+        return apply({ ...operation, node: rewritten })
       }
     }
 
@@ -45,6 +40,48 @@ export function withUniqueIds(editor: Editor) {
   }
 
   return editor
+}
+
+/**
+ * Walk the subtree of `inputNode` and rewrite any Element id that is missing or
+ * that collides with an existing id in the editor (or with one already assigned
+ * earlier in the walk). Returns a cloned node with rewrites applied, or null if
+ * no rewrite was necessary.
+ */
+function rewriteSubtreeIds(editor: Editor, inputNode: Node): Node | null {
+  if (!Element.isElement(inputNode)) return null
+
+  const existing = collectExistingIds(editor)
+  let changed = false
+
+  const clone = structuredClone(inputNode)
+
+  const walk = (n: Node) => {
+    if (!Element.isElement(n)) return
+
+    if (!n.id || existing.has(n.id)) {
+      n.id = crypto.randomUUID()
+      changed = true
+    }
+    existing.add(n.id as string)
+
+    for (const child of n.children) {
+      walk(child)
+    }
+  }
+
+  walk(clone)
+  return changed ? clone : null
+}
+
+function collectExistingIds(editor: Editor): Set<string> {
+  const ids = new Set<string>()
+  for (const [n] of Editor.nodes(editor, { at: [], mode: 'all' })) {
+    if (!Editor.isEditor(n) && Element.isElement(n) && typeof n.id === 'string') {
+      ids.add(n.id)
+    }
+  }
+  return ids
 }
 
 function idExists(editor: Editor, node: NodeWithId): boolean {

--- a/tests/BlockAwarePaste.test.tsx
+++ b/tests/BlockAwarePaste.test.tsx
@@ -1,0 +1,268 @@
+import { describe, test, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSlateStatic } from 'slate-react'
+import { type PropsWithChildren } from 'react'
+import type { Descendant, Editor } from 'slate'
+import { TextbitRoot } from '../lib/components/TextbitRoot'
+import { TextbitEditable } from '../lib/components/TextbitEditable/TextbitEditable'
+import { prepareBlockAwarePaste } from '../lib/utils/blockAwarePaste'
+import { adjacentBlockContent } from './_fixtures'
+import type { AdjacentBlockState } from '../lib/contexts/AdjacentBlockContext'
+import type { BlockSelectionState } from '../lib/contexts/BlockSelectionContext'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal DataTransfer-like stub. `slateFragment`, if given, is
+ * encoded the same way slate-react writes it to the clipboard.
+ */
+function makeClipboard(opts: {
+  slateFragment?: Descendant[]
+  text?: string
+}): DataTransfer {
+  const store = new Map<string, string>()
+  if (opts.slateFragment) {
+    const json = JSON.stringify(opts.slateFragment)
+    store.set('application/x-slate-fragment', window.btoa(encodeURIComponent(json)))
+  }
+  if (opts.text != null) {
+    store.set('text/plain', opts.text)
+  }
+
+  return {
+    types: Array.from(store.keys()),
+    getData: (type: string) => store.get(type) ?? ''
+  } as unknown as DataTransfer
+}
+
+function makeEditor(content: Descendant[] = adjacentBlockContent): Editor {
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <TextbitRoot value={content} onChange={() => { }}>
+        <TextbitEditable>{children}</TextbitEditable>
+      </TextbitRoot>
+    )
+  }
+  const { result: { current: editor } } = renderHook(() => useSlateStatic(), { wrapper: Wrapper })
+  vi.spyOn(editor, 'onChange').mockImplementation(() => { })
+  return editor
+}
+
+function makeFragment(texts: Array<{ id: string; text: string; role?: string }>): Descendant[] {
+  return texts.map(({ id, text, role }) => ({
+    id,
+    type: 'core/text',
+    class: 'text',
+    properties: role ? { role } : {},
+    children: [{ text }]
+  })) as Descendant[]
+}
+
+// ---------------------------------------------------------------------------
+// Slate-fragment paste with block caret
+// ---------------------------------------------------------------------------
+
+describe('prepareBlockAwarePaste — slate-fragment with block caret', () => {
+  test('direction=before inserts fragment before the target block', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'before' }
+    const fragment = makeFragment([{ id: 'f-1', text: 'Pasted' }])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    expect(result).toBe('handled')
+    expect(editor.children).toHaveLength(4)
+    expect(editor.children[1]).toMatchObject({ id: 'f-1' })
+    expect(editor.children[2]).toMatchObject({ id: 'non-text-block' })
+  })
+
+  test('direction=after inserts fragment after the target block', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'after' }
+    const fragment = makeFragment([{ id: 'f-1', text: 'Pasted' }])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    expect(result).toBe('handled')
+    expect(editor.children).toHaveLength(4)
+    expect(editor.children[1]).toMatchObject({ id: 'non-text-block' })
+    expect(editor.children[2]).toMatchObject({ id: 'f-1' })
+    expect(editor.children[3]).toMatchObject({ id: 'text-after-block' })
+  })
+
+  test('preserves role of each pasted block (no merge rewriting)', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'before' }
+    const fragment = makeFragment([
+      { id: 'h1', text: 'Heading', role: 'h1' },
+      { id: 'body', text: 'Body paragraph' }
+    ])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    expect(editor.children[1]).toMatchObject({ id: 'h1', properties: { role: 'h1' } })
+    expect(editor.children[2]).toMatchObject({ id: 'body' })
+  })
+
+  test('selection lands at the end of the last inserted block', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'after' }
+    const fragment = makeFragment([
+      { id: 'f-1', text: 'First' },
+      { id: 'f-2', text: 'Second paragraph' }
+    ])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    // The last inserted block sits at index [2 + 2 - 1] = 3; its text length is
+    // 'Second paragraph'.length = 16
+    expect(editor.selection).toEqual({
+      anchor: { path: [3, 0], offset: 16 },
+      focus: { path: [3, 0], offset: 16 }
+    })
+  })
+
+  test('returns unhandled when block id cannot be resolved', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'no-such-block', direction: 'before' }
+    const clipboard = makeClipboard({ slateFragment: makeFragment([{ id: 'f', text: 'x' }]) })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    expect(result).toBe('unhandled')
+    expect(editor.children).toHaveLength(3) // unchanged
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Slate-fragment paste with block selection
+// ---------------------------------------------------------------------------
+
+describe('prepareBlockAwarePaste — slate-fragment with block selection', () => {
+  test('single-block selection replaces that block with the fragment', () => {
+    const editor = makeEditor()
+    const blockSelection: BlockSelectionState = { anchorIndex: 1, focusIndex: 1 }
+    const fragment = makeFragment([{ id: 'f-1', text: 'Replacement' }])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, null, blockSelection)
+
+    expect(result).toBe('handled')
+    expect(editor.children).toHaveLength(3)
+    expect(editor.children[0]).toMatchObject({ id: 'text-before-block' })
+    expect(editor.children[1]).toMatchObject({ id: 'f-1' })
+    expect(editor.children[2]).toMatchObject({ id: 'text-after-block' })
+  })
+
+  test('multi-block selection replaces the whole range with the fragment', () => {
+    const editor = makeEditor()
+    const blockSelection: BlockSelectionState = { anchorIndex: 0, focusIndex: 2 }
+    const fragment = makeFragment([
+      { id: 'f-1', text: 'One' },
+      { id: 'f-2', text: 'Two' }
+    ])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    prepareBlockAwarePaste(editor, clipboard, null, blockSelection)
+
+    expect(editor.children).toHaveLength(2)
+    expect(editor.children[0]).toMatchObject({ id: 'f-1' })
+    expect(editor.children[1]).toMatchObject({ id: 'f-2' })
+  })
+
+  test('reversed anchor/focus still replaces the correct range', () => {
+    const editor = makeEditor()
+    const blockSelection: BlockSelectionState = { anchorIndex: 2, focusIndex: 0 }
+    const fragment = makeFragment([{ id: 'f-1', text: 'All' }])
+    const clipboard = makeClipboard({ slateFragment: fragment })
+
+    prepareBlockAwarePaste(editor, clipboard, null, blockSelection)
+
+    expect(editor.children).toHaveLength(1)
+    expect(editor.children[0]).toMatchObject({ id: 'f-1' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Text / HTML paste — placeholder path
+// ---------------------------------------------------------------------------
+
+describe('prepareBlockAwarePaste — text/html placeholder path', () => {
+  test('inserts an empty text placeholder at the target path when no slate fragment is present', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'before' }
+    const clipboard = makeClipboard({ text: 'hello' })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, adjacentBlock, null)
+
+    expect(result).toBe('prepared')
+    expect(editor.children).toHaveLength(4)
+    // The placeholder sits at index 1, pushing non-text-block to index 2
+    expect(editor.children[1]).toMatchObject({
+      type: 'core/text',
+      class: 'text',
+      children: [{ text: '' }]
+    })
+    expect(editor.children[2]).toMatchObject({ id: 'non-text-block' })
+
+    // Selection is placed inside the placeholder so the default paste flow
+    // can populate it via editor.insertData.
+    expect(editor.selection).toEqual({
+      anchor: { path: [1, 0], offset: 0 },
+      focus: { path: [1, 0], offset: 0 }
+    })
+  })
+
+  test('block-selection placeholder path removes selected blocks before inserting', () => {
+    const editor = makeEditor()
+    const blockSelection: BlockSelectionState = { anchorIndex: 0, focusIndex: 2 }
+    const clipboard = makeClipboard({ text: 'hello' })
+
+    const result = prepareBlockAwarePaste(editor, clipboard, null, blockSelection)
+
+    expect(result).toBe('prepared')
+    expect(editor.children).toHaveLength(1)
+    expect(editor.children[0]).toMatchObject({
+      type: 'core/text',
+      class: 'text',
+      children: [{ text: '' }]
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Passthrough cases
+// ---------------------------------------------------------------------------
+
+describe('prepareBlockAwarePaste — passthrough', () => {
+  test('returns unhandled when neither adjacentBlock nor blockSelection is set', () => {
+    const editor = makeEditor()
+    const before = editor.children.length
+    const result = prepareBlockAwarePaste(editor, makeClipboard({ text: 'x' }), null, null)
+
+    expect(result).toBe('unhandled')
+    expect(editor.children).toHaveLength(before)
+  })
+
+  test('tolerates malformed slate fragment payload (falls back to placeholder)', () => {
+    const editor = makeEditor()
+    const adjacentBlock: AdjacentBlockState = { blockId: 'non-text-block', direction: 'before' }
+    const badClipboard = {
+      types: ['application/x-slate-fragment'],
+      getData: (t: string) => (t === 'application/x-slate-fragment' ? 'not-valid-base64!!!' : '')
+    } as unknown as DataTransfer
+
+    const result = prepareBlockAwarePaste(editor, badClipboard, adjacentBlock, null)
+
+    // With invalid fragment, fall back to the placeholder path
+    expect(result).toBe('prepared')
+    expect(editor.children).toHaveLength(4)
+    expect(editor.children[1]).toMatchObject({ class: 'text', children: [{ text: '' }] })
+  })
+})

--- a/tests/withInsertFragment.test.tsx
+++ b/tests/withInsertFragment.test.tsx
@@ -1,0 +1,194 @@
+import { describe, test, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSlateStatic } from 'slate-react'
+import { type PropsWithChildren } from 'react'
+import type { Descendant, Editor, Element } from 'slate'
+import { Transforms, Editor as SlateEditor } from 'slate'
+import { TextbitRoot } from '../lib/components/TextbitRoot'
+import { TextbitEditable } from '../lib/components/TextbitEditable/TextbitEditable'
+import { consecutiveBlocksContent } from './_fixtures'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEditor(content: Descendant[] = consecutiveBlocksContent): Editor {
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <TextbitRoot value={content} onChange={() => { }}>
+        <TextbitEditable>{children}</TextbitEditable>
+      </TextbitRoot>
+    )
+  }
+  const { result: { current: editor } } = renderHook(() => useSlateStatic(), { wrapper: Wrapper })
+  vi.spyOn(editor, 'onChange').mockImplementation(() => { })
+  return editor
+}
+
+function imageBlock(id: string, caption: string): Descendant {
+  return {
+    type: 'core/image',
+    id,
+    class: 'block',
+    children: [
+      {
+        type: 'core/image/image',
+        class: 'void',
+        children: [{ text: '' }]
+      },
+      {
+        id: `${id}-caption`,
+        type: 'core/text',
+        class: 'text',
+        properties: {},
+        children: [{ text: caption }]
+      }
+    ]
+  } as Descendant
+}
+
+// ---------------------------------------------------------------------------
+// Insert block fragment into middle of top-level text paragraph
+// ---------------------------------------------------------------------------
+
+describe('withInsertFragment — block into text paragraph', () => {
+  test('splits paragraph and inserts block between halves', () => {
+    const editor = makeEditor()
+    // consecutiveBlocksContent: [para-before, block-1, block-2, para-after]
+    // Place cursor in the middle of para-before "Bef|ore"
+    Transforms.select(editor, { anchor: { path: [0, 0], offset: 3 }, focus: { path: [0, 0], offset: 3 } })
+
+    const fragment = [imageBlock('pasted-img', 'Pasted caption')]
+    editor.insertFragment(fragment)
+
+    // Expected: ["Bef", pasted-img, "ore", block-1, block-2, para-after]
+    expect(editor.children).toHaveLength(6)
+
+    const first = editor.children[0] as Element
+    expect(first.class).toBe('text')
+    expect(first.children).toMatchObject([{ text: 'Bef' }])
+
+    const inserted = editor.children[1] as Element
+    expect(inserted.type).toBe('core/image')
+    expect(inserted.class).toBe('block')
+    expect(inserted.children).toHaveLength(2)
+    expect(inserted.children[0]).toMatchObject({ class: 'void' })
+
+    const second = editor.children[2] as Element
+    expect(second.class).toBe('text')
+    expect(second.children).toMatchObject([{ text: 'ore' }])
+  })
+
+  test('inserts block before paragraph when cursor is at start', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, SlateEditor.start(editor, [0]))
+
+    editor.insertFragment([imageBlock('pasted', 'Caption')])
+
+    // Expected: [pasted, para-before, block-1, block-2, para-after]
+    expect(editor.children).toHaveLength(5)
+    expect((editor.children[0] as Element).type).toBe('core/image')
+    expect((editor.children[1] as Element).class).toBe('text')
+    expect((editor.children[1] as Element).children).toMatchObject([{ text: 'Before' }])
+  })
+
+  test('inserts block after paragraph when cursor is at end', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, SlateEditor.end(editor, [0]))
+
+    editor.insertFragment([imageBlock('pasted', 'Caption')])
+
+    // Expected: [para-before, pasted, block-1, block-2, para-after]
+    expect(editor.children).toHaveLength(5)
+    expect((editor.children[0] as Element).class).toBe('text')
+    expect((editor.children[0] as Element).children).toMatchObject([{ text: 'Before' }])
+    expect((editor.children[1] as Element).type).toBe('core/image')
+  })
+
+  test('preserves void child in the inserted block', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, { anchor: { path: [0, 0], offset: 3 }, focus: { path: [0, 0], offset: 3 } })
+
+    editor.insertFragment([imageBlock('pasted', 'My caption')])
+
+    const inserted = editor.children[1] as Element
+    const voidChild = inserted.children[0] as Element
+    expect(voidChild.type).toBe('core/image/image')
+    expect(voidChild.class).toBe('void')
+
+    const captionChild = inserted.children[1] as Element
+    expect(captionChild.class).toBe('text')
+    expect(captionChild.children).toMatchObject([{ text: 'My caption' }])
+  })
+
+  test('places cursor at end of last inserted fragment node', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, { anchor: { path: [0, 0], offset: 3 }, focus: { path: [0, 0], offset: 3 } })
+
+    editor.insertFragment([imageBlock('pasted', 'Pasted caption')])
+
+    // Last inserted node is at index 1; its last text child has "Pasted caption" (length 14)
+    expect(editor.selection).toEqual({
+      anchor: { path: [1, 1, 0], offset: 14 },
+      focus: { path: [1, 1, 0], offset: 14 }
+    })
+  })
+
+  test('handles multiple blocks in the fragment', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, { anchor: { path: [0, 0], offset: 3 }, focus: { path: [0, 0], offset: 3 } })
+
+    editor.insertFragment([
+      imageBlock('img-1', 'First'),
+      imageBlock('img-2', 'Second')
+    ])
+
+    // Expected: ["Bef", img-1, img-2, "ore", block-1, block-2, para-after]
+    expect(editor.children).toHaveLength(7)
+    expect((editor.children[0] as Element).children).toMatchObject([{ text: 'Bef' }])
+    expect((editor.children[1] as Element).type).toBe('core/image')
+    expect((editor.children[2] as Element).type).toBe('core/image')
+    expect((editor.children[3] as Element).children).toMatchObject([{ text: 'ore' }])
+  })
+
+  test('handles non-collapsed selection within the paragraph', () => {
+    const editor = makeEditor()
+    // Select "efo" in "Before" (offset 1 to 4)
+    Transforms.select(editor, {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [0, 0], offset: 4 }
+    })
+
+    editor.insertFragment([imageBlock('pasted', 'Caption')])
+
+    // "B" + pasted-img + "re" (selected "efo" was deleted, then split at cursor)
+    expect(editor.children).toHaveLength(6)
+    expect((editor.children[0] as Element).children).toMatchObject([{ text: 'B' }])
+    expect((editor.children[1] as Element).type).toBe('core/image')
+    expect((editor.children[2] as Element).children).toMatchObject([{ text: 're' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Ensure existing text-only fragment behavior is preserved
+// ---------------------------------------------------------------------------
+
+describe('withInsertFragment — text-only fragment passthrough', () => {
+  test('text fragment pasted into text paragraph uses default behavior', () => {
+    const editor = makeEditor()
+    Transforms.select(editor, { anchor: { path: [0, 0], offset: 3 }, focus: { path: [0, 0], offset: 3 } })
+
+    const textFragment: Descendant[] = [{
+      type: 'core/text',
+      id: 'frag-text',
+      class: 'text',
+      properties: {},
+      children: [{ text: 'INSERTED' }]
+    }]
+
+    editor.insertFragment(textFragment)
+
+    // Text should be merged into the paragraph, not split
+    expect((editor.children[0] as Element).class).toBe('text')
+  })
+})

--- a/tests/withUniqueIds.test.ts
+++ b/tests/withUniqueIds.test.ts
@@ -1,0 +1,316 @@
+import { describe, test, expect } from 'vitest'
+import { createEditor, type Descendant, type Editor } from 'slate'
+import { withUniqueIds } from '../lib/with/withUniqueIds'
+
+function makeEditor(initial: Descendant[]): Editor {
+  const editor = withUniqueIds(createEditor())
+  editor.children = initial
+  return editor
+}
+
+describe('withUniqueIds — top-level node', () => {
+  test('assigns a new id when inserted node has no id', () => {
+    const editor = makeEditor([])
+    editor.apply({
+      type: 'insert_node',
+      path: [0],
+      node: {
+        type: 'core/text',
+        class: 'text',
+        children: [{ text: 'a' }]
+      } as Descendant
+    })
+
+    expect(editor.children).toHaveLength(1)
+    const inserted = editor.children[0] as { id?: string }
+    expect(typeof inserted.id).toBe('string')
+    expect(inserted.id).not.toBe('')
+  })
+
+  test('rewrites id when inserted node collides with an existing id', () => {
+    const editor = makeEditor([
+      { type: 'core/text', class: 'text', id: 'dup', properties: {}, children: [{ text: 'x' }] }
+    ])
+
+    editor.apply({
+      type: 'insert_node',
+      path: [1],
+      node: {
+        type: 'core/text',
+        class: 'text',
+        id: 'dup',
+        properties: {},
+        children: [{ text: 'y' }]
+      } as Descendant
+    })
+
+    const first = editor.children[0] as { id: string }
+    const second = editor.children[1] as { id: string }
+    expect(first.id).toBe('dup')
+    expect(second.id).not.toBe('dup')
+    expect(second.id).toBeTruthy()
+  })
+
+  test('keeps id when the inserted node has a unique id', () => {
+    const editor = makeEditor([
+      { type: 'core/text', class: 'text', id: 'one', properties: {}, children: [{ text: 'x' }] }
+    ])
+
+    editor.apply({
+      type: 'insert_node',
+      path: [1],
+      node: {
+        type: 'core/text',
+        class: 'text',
+        id: 'two',
+        properties: {},
+        children: [{ text: 'y' }]
+      } as Descendant
+    })
+
+    const second = editor.children[1] as { id: string }
+    expect(second.id).toBe('two')
+  })
+})
+
+describe('withUniqueIds — nested children', () => {
+  test('rewrites a colliding CHILD id while preserving the top-level id', () => {
+    const editor = makeEditor([
+      {
+        type: 'core/image',
+        class: 'block',
+        id: 'outer',
+        children: [
+          {
+            id: 'inner',
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'original caption' }]
+          }
+        ]
+      } as Descendant
+    ])
+
+    // Insert a block whose top id is unique, but whose child id collides.
+    editor.apply({
+      type: 'insert_node',
+      path: [1],
+      node: {
+        type: 'core/image',
+        class: 'block',
+        id: 'outer-2',
+        children: [
+          {
+            id: 'inner',
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'pasted caption' }]
+          }
+        ]
+      } as Descendant
+    })
+
+    const original = editor.children[0] as {
+      id: string
+      children: Array<{ id: string }>
+    }
+    const pasted = editor.children[1] as {
+      id: string
+      children: Array<{ id: string }>
+    }
+
+    expect(original.id).toBe('outer')
+    expect(original.children[0].id).toBe('inner')
+
+    expect(pasted.id).toBe('outer-2')
+    expect(pasted.children[0].id).not.toBe('inner')
+    expect(pasted.children[0].id).toBeTruthy()
+  })
+
+  test('rewrites BOTH top-level id and colliding child id when both collide', () => {
+    const editor = makeEditor([
+      {
+        type: 'core/image',
+        class: 'block',
+        id: 'blk',
+        children: [
+          {
+            id: 'cap',
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'original' }]
+          }
+        ]
+      } as Descendant
+    ])
+
+    editor.apply({
+      type: 'insert_node',
+      path: [1],
+      node: {
+        type: 'core/image',
+        class: 'block',
+        id: 'blk',
+        children: [
+          {
+            id: 'cap',
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'pasted' }]
+          }
+        ]
+      } as Descendant
+    })
+
+    const inserted = editor.children[1] as {
+      id: string
+      children: Array<{ id: string }>
+    }
+    expect(inserted.id).not.toBe('blk')
+    expect(inserted.children[0].id).not.toBe('cap')
+
+    // Verify overall uniqueness across the whole editor
+    const allIds = collectAllIds(editor.children)
+    expect(new Set(allIds).size).toBe(allIds.length)
+  })
+
+  test('assigns ids to children that are missing an id', () => {
+    const editor = makeEditor([])
+
+    editor.apply({
+      type: 'insert_node',
+      path: [0],
+      node: {
+        type: 'core/image',
+        class: 'block',
+        id: 'has-id',
+        children: [
+          // child without id
+          {
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'caption' }]
+          }
+        ]
+      } as Descendant
+    })
+
+    const inserted = editor.children[0] as {
+      id: string
+      children: Array<{ id?: string }>
+    }
+    expect(inserted.id).toBe('has-id')
+    expect(typeof inserted.children[0].id).toBe('string')
+    expect(inserted.children[0].id).toBeTruthy()
+  })
+
+  test('rewrites duplicate ids that collide WITHIN the same inserted subtree', () => {
+    const editor = makeEditor([])
+
+    editor.apply({
+      type: 'insert_node',
+      path: [0],
+      node: {
+        type: 'core/image',
+        class: 'block',
+        id: 'twin',
+        children: [
+          {
+            id: 'twin',
+            type: 'core/text',
+            class: 'text',
+            properties: {},
+            children: [{ text: 'inner with same id' }]
+          }
+        ]
+      } as Descendant
+    })
+
+    const inserted = editor.children[0] as {
+      id: string
+      children: Array<{ id: string }>
+    }
+    // One of the two 'twin' ids must have been rewritten so they no longer collide
+    expect(inserted.id).not.toBe(inserted.children[0].id)
+  })
+
+  test('does not modify the caller-provided node object when rewriting', () => {
+    const editor = makeEditor([
+      { type: 'core/text', class: 'text', id: 'dup', properties: {}, children: [{ text: 'x' }] }
+    ])
+
+    const input = {
+      type: 'core/image',
+      class: 'block',
+      id: 'dup',
+      children: [
+        {
+          id: 'dup',
+          type: 'core/text',
+          class: 'text',
+          properties: {},
+          children: [{ text: 'inner' }]
+        }
+      ]
+    } as Descendant
+
+    editor.apply({ type: 'insert_node', path: [1], node: input })
+
+    // Caller's object should remain untouched
+    expect((input as { id: string }).id).toBe('dup')
+    expect(((input as { children: Array<{ id: string }> }).children[0]).id).toBe('dup')
+  })
+})
+
+describe('withUniqueIds — split_node', () => {
+  test('rewrites the split id when it collides', () => {
+    const editor = makeEditor([
+      {
+        type: 'core/text',
+        class: 'text',
+        id: 'split-me',
+        properties: {},
+        children: [{ text: 'hello world' }]
+      }
+    ])
+
+    editor.apply({
+      type: 'split_node',
+      path: [0],
+      position: 5,
+      properties: {
+        type: 'core/text',
+        class: 'text',
+        id: 'split-me',
+        properties: {}
+      },
+      // slate expects 'properties' to describe the new node; include minimally typed fields
+    } as never)
+
+    const nodes = editor.children as Array<{ id: string }>
+    expect(nodes[0].id).toBe('split-me')
+    expect(nodes[1].id).not.toBe('split-me')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function collectAllIds(nodes: Descendant[]): string[] {
+  const ids: string[] = []
+  const walk = (n: Descendant) => {
+    const maybeId = (n as { id?: string }).id
+    if (typeof maybeId === 'string') ids.push(maybeId)
+    if ('children' in n && Array.isArray(n.children)) {
+      for (const c of n.children) walk(c as Descendant)
+    }
+  }
+  for (const n of nodes) walk(n)
+  return ids
+}


### PR DESCRIPTION
When block caret is active to the left or right of a block element, use `shift+arrow` to select whole blocks instead of text in blocks. Any actions (copy, cut, paste, hitting a character key) will be affect the full blocks instead of text range.