### PR TITLE
Droppable: add vertical spacing to block class elements

### DIFF
--- a/lib/components/Element/Droppable.tsx
+++ b/lib/components/Element/Droppable.tsx
@@ -126,6 +126,7 @@ export function Droppable({ children, element }: {
     <div
       data-id={element?.id || ''}
       ref={ref}
+      style={element?.class === 'block' ? { marginTop: 'var(--tb-block-spacing, 8px)' } : undefined}
       draggable={['block', 'void'].includes(element?.class || '') ? 'true' : 'false'}
       onDragStartCapture={onDragStartCapture}
       onDragEnterCapture={onDragEnterCapture}


### PR DESCRIPTION
Adds a bit of vertical spacing to block class elements.