### PR TITLE
Add min/max constraints to child elements definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,11 +1147,14 @@ const MyPlugin: TBPluginInitFunction = (options) => {
     }],
     
     componentEntry: {
-      class: 'void',
+      class: 'block',
       component: Figure,
-      constraints: {
-        normalizeNode: normalizeImage
-      }
+      children: [
+        { type: 'image', class: 'void', component: ImageContent,
+          constraints: { min: 1, max: 1 } },
+        { type: 'caption', class: 'text', component: Caption,
+          constraints: { allowBreak: false, min: 1, max: 1 } }
+      ]
     },
     
     // Optional: Plugin options
@@ -1185,7 +1188,29 @@ Constraints control editing behavior within a component. They are set in the `co
 | `allowEdgeWhitespace` | `boolean` | `true` | When `false`, prevents Space from adding a whitespace character at the first position. If one or more whitespace characters are left trailing at the last position or after, these will be removed on the following blur event |
 | `normalizeNode` | `(editor, nodeEntry) => boolean \| void` | — | Custom normalization function; return `true` to signal the normalization was handled |
 
-See the [Image Block Plugin example](#example-image-block-plugin) below for a practical demonstration of `allowBreak` and `normalizeNode`.
+### Child count constraints (`min` / `max`)
+
+A child component entry (an item in a parent's `children` array) can declare how many instances of its type are allowed inside the parent. These fields sit **inside `constraints`** alongside the behavior-level fields above:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `min` | `number` | — | Minimum number of instances required in the parent. If the count ever drops below `min`, Textbit inserts a minimal placeholder to restore the invariant. |
+| `max` | `number` | — | Maximum number of instances allowed in the parent. Enter is blocked when the count is already at `max`; excess siblings are removed by the normalizer. |
+
+`min` and `max` are only valid on **child entries**. TypeScript will reject them on a top-level `componentEntry` — the `ComponentEntry` type forbids them, while entries inside a `children` array are typed as `ChildComponentEntry` and accept them.
+
+**Form-field semantics:** set both to `1` to model a permanent sub-element that always exists exactly once (e.g., an image caption). The user cannot delete it — if they try, it is re-inserted — and Enter cannot split it into a second one. Parent blocks are never removed because of child constraints.
+
+Textbit enforces these automatically:
+
+- **Normalization:** on every change, `min <= count <= max` is restored by inserting placeholders or removing excess siblings, in the order defined by the parent's `children` array.
+- **Enter:** blocked inside a child whose type is already at `max` in the parent.
+- **Paste:** pasting a block-level fragment inside any child text element (e.g., a caption — whether or not it has `min`/`max` set) is flattened to plain text so it cannot corrupt the parent block's structure.
+- **Delete / Backspace:** handled reactively by the normalizer — a `min: 1` child is re-inserted synchronously if removed.
+
+This replaces the boilerplate normalizer that plugins used to need for "exactly one of X, at most one of Y" rules. Plugins can still define a custom `normalizeNode` alongside these for anything more exotic; it runs after the declarative enforcement.
+
+See the [Image Block Plugin example](#example-image-block-plugin) below for a practical demonstration of `allowBreak`, `min`, and `max`.
 
 ### Example: Bold Plugin
 
@@ -1321,21 +1346,21 @@ const Image: TBPluginInitFunction = () => {
     componentEntry: {
       class: 'block',
       component: FigureComponent,
-      constraints: {
-        normalizeNode: normalizeImage
-      },
       children: [
         {
           type: 'image',
           class: 'void',
-          component: ImageComponent
+          component: ImageComponent,
+          constraints: { min: 1, max: 1 }
         },
         {
           type: 'text',
           class: 'text',
           component: CaptionComponent,
           constraints: {
-            allowBreak: false
+            allowBreak: false,
+            min: 1,
+            max: 1
           }
         }
       ]

--- a/lib/components/Element/ChildElement.tsx
+++ b/lib/components/Element/ChildElement.tsx
@@ -4,10 +4,10 @@ import {
 } from 'react'
 import { Element } from 'slate'
 import { useSlateStatic, type RenderElementProps } from 'slate-react'
-import type { ComponentEntry } from '../../types'
+import type { ChildComponentEntry } from '../../types'
 
 interface ChildElementProps extends RenderElementProps {
-  entry: ComponentEntry
+  entry: ChildComponentEntry
   rootNode: Element
   options?: Record<string, unknown>
 }

--- a/lib/components/Element/InlineElement.tsx
+++ b/lib/components/Element/InlineElement.tsx
@@ -1,8 +1,8 @@
 import { useSlateStatic, type RenderElementProps } from 'slate-react'
-import type { ComponentEntry } from '../../types'
+import type { ChildComponentEntry } from '../../types'
 
 interface InlineElementProps extends RenderElementProps {
-  entry: ComponentEntry
+  entry: ChildComponentEntry
   options?: Record<string, unknown>
 }
 

--- a/lib/components/Element/ParentElement.tsx
+++ b/lib/components/Element/ParentElement.tsx
@@ -1,12 +1,12 @@
 import { useSelected, useSlateStatic, type RenderElementProps } from 'slate-react'
 import { Droppable } from './Droppable'
-import type { ComponentEntry } from '../../types'
+import type { ChildComponentEntry } from '../../types'
 import { useAdjacentBlock } from '../../hooks/useAdjacentBlock'
 import { useBlockSelection } from '../../hooks/useBlockSelection'
 import { CSSProperties } from 'react'
 
 interface ParentElementProps extends RenderElementProps {
-  entry: ComponentEntry
+  entry: ChildComponentEntry
   options?: Record<string, unknown>
 }
 

--- a/lib/components/SlateContainer.tsx
+++ b/lib/components/SlateContainer.tsx
@@ -103,7 +103,7 @@ export function SlateContainer(props: SlateContainerProps) {
     }
     withTextbitElements(editor)
     withInsertText(editor, plugins)
-    withInsertFragment(editor)
+    withInsertFragment(editor, components)
     withNormalizeNode(editor, plugins, components)
     withEditableVoids(editor, components)
     withTrimWhitespace(editor)

--- a/lib/contexts/PluginRegistry/lib/registerComponents.ts
+++ b/lib/contexts/PluginRegistry/lib/registerComponents.ts
@@ -1,8 +1,12 @@
-import type { Options, ComponentEntry } from '../../../types/textbit'
+import type { Options, ChildComponentEntry } from '../../../types/textbit'
 import type { PluginRegistryComponent } from './types'
 
 /**
- * Register a plugin component and it's component child components recursively
+ * Register a plugin component and it's component child components recursively.
+ *
+ * `ChildComponentEntry` is used as the parameter type because it is the wider
+ * of the two entry types — every top-level `ComponentEntry` is structurally
+ * assignable to it, and nested child entries are always `ChildComponentEntry`.
  *
  * @param components
  * @param componentType
@@ -12,7 +16,7 @@ import type { PluginRegistryComponent } from './types'
 export const registerComponents = (
   currentComponents: Map<string, PluginRegistryComponent>,
   componentType: string,
-  entry: ComponentEntry,
+  entry: ChildComponentEntry,
   options?: { verbose: boolean },
   pluginOptions?: Options
 ) => {
@@ -29,10 +33,10 @@ export const registerComponents = (
 const registerComponent = (
   components: Map<string, PluginRegistryComponent>,
   componentType: string,
-  entry: ComponentEntry,
+  entry: ChildComponentEntry,
   options: {
     verbose?: boolean
-    parent?: ComponentEntry
+    parent?: ChildComponentEntry
   },
   pluginOptions: Record<string, unknown>
 ) => {

--- a/lib/contexts/PluginRegistry/lib/types.ts
+++ b/lib/contexts/PluginRegistry/lib/types.ts
@@ -1,15 +1,22 @@
 import type { KeyboardEventLike } from 'is-hotkey'
-import type { PluginDefinition, Action, ComponentEntry } from '../../../types'
+import type { PluginDefinition, Action, ChildComponentEntry } from '../../../types'
 
 /**
  * @type
- * A renderable component
+ * A renderable component.
+ *
+ * `componentEntry` / `parent` are typed as `ChildComponentEntry` — the widest
+ * of the two entry types — so this field can store both top-level and child
+ * entries. A top-level `ComponentEntry` is structurally assignable to
+ * `ChildComponentEntry` because its `min`/`max` are typed `never` (a subtype
+ * of `number`). Internal code can read `constraints?.min` / `constraints?.max`
+ * through this field.
  */
 export type PluginRegistryComponent = {
   type: string
   class: string
-  componentEntry: ComponentEntry
-  parent: ComponentEntry | null
+  componentEntry: ChildComponentEntry
+  parent: ChildComponentEntry | null
   pluginOptions: Record<string, unknown>
 }
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,6 +8,7 @@ export type {
   PluginInitFunction as TBPluginInitFunction,
   Resource as TBResource,
   ComponentEntry as TBComponentEntry,
+  ChildComponentEntry as TBChildComponentEntry,
   Component as TBComponent,
   ComponentProps as TBComponentProps,
   ToolComponent as TBToolComponent,

--- a/lib/types/textbit.ts
+++ b/lib/types/textbit.ts
@@ -84,10 +84,63 @@ export interface Action {
 
 
 /**
- * @interface
- * Textbit component interface.
+ * Constraints shared by any component entry, regardless of whether it is a
+ * top-level entry or a child entry in a parent's `children` array.
  */
-export interface ComponentEntry<T extends HTMLElement = HTMLElement> {
+interface BaseConstraints {
+  /** If true, prevents <enter> from having any effect, default is true */
+  allowBreak?: boolean
+
+  /** If true, prevents soft breaks (i.e breaks within one text element, default is true */
+  allowSoftBreak?: boolean
+
+  /** If false, prevents <enter> from exiting the top-level block when at the last position, default is true */
+  allowExitBreak?: boolean
+
+  /** If false, prevents whitespace at the start and end of a paragraph, default is true */
+  allowEdgeWhitespace?: boolean
+
+  /** Normalizer function, optional */
+  normalizeNode?: (editor: Editor, nodeEntry: NodeEntry) => boolean | void
+}
+
+/**
+ * Constraints valid on TOP-LEVEL component entries (e.g. the entry directly
+ * on a PluginDefinition). Cardinality constraints (`min`/`max`) are typed
+ * `never` so TypeScript rejects them at the plugin definition site — they
+ * are only meaningful when the entry appears in a parent's `children` array.
+ */
+export interface TopLevelConstraints extends BaseConstraints {
+  min?: never
+  max?: never
+}
+
+/**
+ * Constraints valid on CHILD component entries (items in a parent's
+ * `children` array). Adds the cardinality constraints `min` and `max`.
+ */
+export interface ChildConstraints extends BaseConstraints {
+  /**
+   * Minimum number of instances of this child type allowed within the parent.
+   * If the count ever falls below `min`, the normalizer inserts a minimal
+   * placeholder to restore the invariant. Use `min: 1, max: 1` to model a
+   * permanent form-field-like child that always exists and cannot be removed.
+   */
+  min?: number
+
+  /**
+   * Maximum number of instances of this child type allowed within the parent.
+   * Excess siblings are removed by the normalizer; Enter is blocked when the
+   * count is already at `max`.
+   */
+  max?: number
+}
+
+/**
+ * Fields common to every component entry, independent of whether it is used
+ * as a top-level or child entry.
+ */
+interface BaseComponentEntry<T extends HTMLElement = HTMLElement> {
   /** Class of the component, inherited from plugin if not specified. ('leaf' | 'inline' | 'text' | 'textblock' | 'block' | 'void' | 'generic') */
   class: string
 
@@ -110,29 +163,28 @@ export interface ComponentEntry<T extends HTMLElement = HTMLElement> {
   // Children must be able to use any element, not only HTMLElement.
   // Type safety is enforced at the component level through Component<T>.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  children?: ComponentEntry<any>[]
+  children?: ChildComponentEntry<any>[]
+}
 
+/**
+ * @interface
+ * A top-level component entry (e.g. the one attached to a PluginDefinition).
+ * Accepts every behavior-level constraint but rejects cardinality constraints.
+ */
+export interface ComponentEntry<T extends HTMLElement = HTMLElement> extends BaseComponentEntry<T> {
   /** Hard constraints for the component */
-  constraints?: {
-    // minElements?: number
-    // maxElements?: number
-    // maxLength?: number
+  constraints?: TopLevelConstraints
+}
 
-    /** If true, prevents <enter> from having any effect, default is true */
-    allowBreak?: boolean
-
-    /** If true, prevents soft breaks (i.e breaks within one text element, default is true */
-    allowSoftBreak?: boolean
-
-    /** If false, prevents <enter> from exiting the top-level block when at the last position, default is true */
-    allowExitBreak?: boolean
-
-    /** If false, prevents whitespace at the start and end of a paragraph, default is true */
-    allowEdgeWhitespace?: boolean
-
-    /** Normalizer function, optional */
-    normalizeNode?: (editor: Editor, nodeEntry: NodeEntry) => boolean | void
-  }
+/**
+ * @interface
+ * A child component entry — an item in a parent's `children` array. Accepts
+ * the behavior-level constraints plus `min`/`max` for cardinality within
+ * the parent.
+ */
+export interface ChildComponentEntry<T extends HTMLElement = HTMLElement> extends BaseComponentEntry<T> {
+  /** Hard constraints for the component, including cardinality in the parent */
+  constraints?: ChildConstraints
 }
 
 

--- a/lib/utils/componentConstraints.ts
+++ b/lib/utils/componentConstraints.ts
@@ -1,20 +1,22 @@
-import { type ComponentEntry } from '../types/textbit'
+import { type ComponentEntry, type ChildComponentEntry, type ChildConstraints } from '../types/textbit'
 
-export function componentConstraints(entry: ComponentEntry) {
+export function componentConstraints(entry: ComponentEntry | ChildComponentEntry) {
+  // Read through the widest constraints type — top-level entries simply have
+  // `min` / `max` as `never` (i.e. undefined at runtime).
+  const constraints = (entry?.constraints ?? {}) as ChildConstraints
+
   const {
-    // maxLength = undefined,   // Max length of text content
-    // maxElements = undefined, // Max no of elements in parent
-    // minElements = undefined, // Min no of elements in parent
-    allowBreak, // Allow normal break to create new node of same type
-    allowSoftBreak, // Allow soft break (newline in text node)
+    allowBreak,
+    allowSoftBreak,
     normalizeNode,
-    allowEdgeWhitespace
-  } = entry?.constraints || {}
+    allowEdgeWhitespace,
+    min,
+    max
+  } = constraints
 
   return {
-    // maxLength: maxLength ?? 0, // I.e no limit
-    // maxElements: maxElements ?? 0, // I.e no limit
-    // minElements: minElements ?? 0,
+    min, // Min instances of this child type in parent (undefined = no limit)
+    max, // Max instances of this child type in parent (undefined = no limit)
     allowBreak: allowBreak ?? true,
     allowSoftBreak: allowSoftBreak ?? false,
     allowEdgeWhitespace: allowEdgeWhitespace ?? true,

--- a/lib/with/withInsertBreak.ts
+++ b/lib/with/withInsertBreak.ts
@@ -79,11 +79,29 @@ function allowBreak(
     : [selection.anchor, selection.focus]
 
   for (const point of points) {
-    for (const [node] of Editor.levels(editor, { at: point })) {
-      if (SlateElement.isElement(node)) {
-        const component = components.get(node.type)
-        if (component?.componentEntry?.constraints?.allowBreak === false) {
-          return false
+    for (const [node, nodePath] of Editor.levels(editor, { at: point })) {
+      if (!SlateElement.isElement(node)) continue
+
+      const component = components.get(node.type)
+      if (!component) continue
+
+      if (component.componentEntry?.constraints?.allowBreak === false) {
+        return false
+      }
+
+      // Block the break when this child type is already at its max count in the parent.
+      // Walking levels includes top-level nodes whose path is length 1 — those have no
+      // constraining parent in Textbit's sense, so skip them.
+      const max = component.componentEntry?.constraints?.max
+      if (max !== undefined && nodePath.length > 1) {
+        const parentPath = nodePath.slice(0, -1)
+        const [parentNode] = Editor.node(editor, parentPath)
+        if (SlateElement.isElement(parentNode)) {
+          let count = 0
+          for (const child of parentNode.children) {
+            if (SlateElement.isElement(child) && child.type === node.type) count++
+          }
+          if (count >= max) return false
         }
       }
     }

--- a/lib/with/withInsertFragment.ts
+++ b/lib/with/withInsertFragment.ts
@@ -1,5 +1,6 @@
 import { Editor, Node, Range, Path, Element, Point, Transforms } from 'slate'
 import { TextbitElement } from '../main'
+import type { PluginRegistryComponent } from '../contexts/PluginRegistry/lib/types'
 
 /**
  * Custom insertFragment function that ensures that pasted text into one text node
@@ -15,7 +16,10 @@ import { TextbitElement } from '../main'
  * @param editor
  * @returns
  */
-export function withInsertFragment(editor: Editor) {
+export function withInsertFragment(
+  editor: Editor,
+  components: Map<string, PluginRegistryComponent>
+) {
   const { insertFragment } = editor
 
   editor.insertFragment = (fragment, options) => {
@@ -25,6 +29,18 @@ export function withInsertFragment(editor: Editor) {
     if (!selection) {
       insertFragment(fragment, options)
       return
+    }
+
+    // When the fragment contains non-text blocks and the cursor is inside a
+    // registered child text element (e.g., an image caption), inserting the
+    // blocks as siblings would corrupt the parent block's structure. Flatten
+    // the fragment to plain text and let insertText handle it.
+    if (!fragment.every(TextbitElement.isText)) {
+      if (isInsideChildTextElement(editor, selection, components)) {
+        const text = fragment.map((n) => Node.string(n)).join('\n')
+        editor.insertText(text)
+        return
+      }
     }
 
     // When the fragment contains non-text blocks and the cursor is inside a
@@ -175,4 +191,35 @@ function findClosestTextNodeAncestor(
   }
 
   return null
+}
+
+/**
+ * True when the selection is inside a registered child text element — that
+ * is, a 'text'-class element whose path is nested (length > 1) and whose
+ * plugin registry entry has a non-null parent. Top-level paragraphs return
+ * false so they continue to use the split-and-insert path.
+ */
+function isInsideChildTextElement(
+  editor: Editor,
+  selection: Range,
+  components: Map<string, PluginRegistryComponent>
+): boolean {
+  const path = selection.anchor.path
+  if (path.length <= 1) return false
+
+  // Walk up from the leaf text node looking for the nearest Element ancestor
+  for (let len = path.length - 1; len >= 1; len--) {
+    const ancestorPath = path.slice(0, len)
+    try {
+      const [node] = Editor.node(editor, ancestorPath)
+      if (!Element.isElement(node)) continue
+      if (node.class !== 'text') return false
+      const component = components.get(node.type)
+      if (!component) return false
+      return component.parent !== null
+    } catch {
+      return false
+    }
+  }
+  return false
 }

--- a/lib/with/withNormalizeNode.ts
+++ b/lib/with/withNormalizeNode.ts
@@ -1,18 +1,14 @@
-import { Editor, Element } from 'slate'
-import type { PluginDefinition } from '../types/textbit'
+import { Editor, Element, Transforms, type NodeEntry, type Descendant } from 'slate'
+import type { PluginDefinition, ChildComponentEntry } from '../types/textbit'
 import type { PluginRegistryComponent } from '../contexts/PluginRegistry/lib/types'
 
-// type NormalizerFunc = (editor: Editor, entry: NodeEntry) => true | void
-// type NormalizerMap = Map<string, NormalizerFunc>
-
-// FIXME: Code will eventully be refactored with commented out code (_ -> plugins)
 export function withNormalizeNode(editor: Editor, _: PluginDefinition[], components: Map<string, PluginRegistryComponent>) {
   const { normalizeNode } = editor
 
   editor.normalizeNode = (nodeEntry) => {
     const [node] = nodeEntry
 
-    // Normalization constraints only supported on Elements
+    // Declarative constraints only apply to Elements
     if (!Element.isElement(node)) {
       return normalizeNode(nodeEntry)
     }
@@ -22,88 +18,171 @@ export function withNormalizeNode(editor: Editor, _: PluginDefinition[], compone
       return normalizeNode(nodeEntry)
     }
 
-    // Use component normalizer if exists
+    // Declarative child-constraint enforcement (excess → missing → order).
+    // Each sub-step returns true if it mutated the tree, in which case we
+    // exit early so Slate re-runs normalization on the updated state.
+    if (enforceChildConstraints(editor, nodeEntry, item)) {
+      return
+    }
+
+    // Custom plugin normalizer runs after declarative enforcement
     if (typeof item.componentEntry.constraints?.normalizeNode === 'function') {
-      if (true === item.componentEntry.constraints?.normalizeNode(editor, nodeEntry)) {
+      if (true === item.componentEntry.constraints.normalizeNode(editor, nodeEntry)) {
         return
       }
     }
 
     normalizeNode(nodeEntry)
-
-    // const parent = Node.parent(editor, path)
-
-    // if (Editor.isEditor(parent) && item.parent) {
-    //     console.log(`${item.type} should be in ${item.parent.type}, but is in editor`)
-    // }
-    // else if (Element.isElement(parent) && item.parent?.type !== parent.type) {
-    //     console.log(`${item.type} should be in ${item.parent?.type || 'editor'}, but is in ${parent.type}`)
-    //     // debugger
-    //     // for (const [child, childPath] of Node.children(editor, path)) {
-    //     //     if (Element.isElement(child)) {
-    //     //         Transforms.unwrapNodes(editor, { at: childPath })
-    //     //         return
-    //     //     }
-    //     // }
-    //     // return
-    // }
-
-    // Check to see if we still have invalid children, then remove them
-    // const allowedChildren = item.component?.children?.map(c => `${item.type}/${c.type}`) || []
-    // for (const [child, childPath] of Node.children(editor, path)) {
-    //     if (Element.isElement(child) && !allowedChildren.includes(child.type)) {
-    //         console.warn(`${item.type} contains ${child.type} but only allows ${allowedChildren.join(', ')}`)
-    //     }
-    // }
-
-    // Check constraints and handle them
-    // const constraints = componentConstraints(item.component)
-
-    // if (constraints.maxElements > 0) {
-
-    // }
-    // else if (constraints.minElements > 0) {
-
-    // }
-    // else if (constraints.maxLength > 0) {
-
-    // }
-    // else {
-    //     return normalizeNode(entry)
-    // }
-
-    // Normalization supported on Elements only as of now. If supported on
-    // leafs, who should handle a leaf with formats e.g "core/bold, core/italic"?
-    // if (Element.isElement(node)) {
-    //     const eventHandler = normalizeHandlers.get(node.type)
-    //     if (eventHandler && true === eventHandler(editor, entry)) {
-    //         // If eventHandler returns true, it has handled it
-    //         return
-    //     }
-    // }
   }
 
   return editor
 }
 
-// function addNormalizerForComponent(componentType: string, normalizers: NormalizerMap, normalizer: NormalizerFunc, entry: Plugin.ComponentEntry) {
-//   normalizers.set(componentType, normalizer)
+/**
+ * Enforce declarative child count / ordering constraints on a parent element.
+ * Returns true if a change was made (caller should exit so normalization re-runs).
+ */
+function enforceChildConstraints(
+  editor: Editor,
+  nodeEntry: NodeEntry,
+  parent: PluginRegistryComponent
+): boolean {
+  const [node, path] = nodeEntry
+  if (!Element.isElement(node)) return false
 
-// As for now we only support normalization to be handled by the plugin
-// (i.e the top component). If child components should have support for
-// normalization they should probably have their own event handlers, not
-// share with the plugin as below.
+  const childDefs = parent.componentEntry.children
+  if (!childDefs || childDefs.length === 0) return false
 
-// if (!Array.isArray(component?.children)) {
-//     return
-// }
+  // Only constrained child types participate in enforcement
+  const constrained = childDefs.filter(
+    (c) => c.constraints?.min !== undefined || c.constraints?.max !== undefined
+  )
+  if (constrained.length === 0) return false
 
-// component.children.forEach(childComponent => {
-//     addNormalizerForComponent(
-//         `${componentType}/${childComponent.type}`,
-//         normalizers,
-//         normalizer,
-//         childComponent
-//     )
-// })
-// }
+  const parentType = parent.type
+
+  // Step 1 — remove excess (count > max)
+  for (const def of constrained) {
+    const max = def.constraints?.max
+    if (max === undefined) continue
+    const fullType = `${parentType}/${def.type}`
+    const indices = childIndicesOfType(node, fullType)
+    if (indices.length > max) {
+      // Remove the last excess child (iterating end→start avoids cascading index shifts)
+      const toRemove = indices[indices.length - 1]
+      Transforms.removeNodes(editor, { at: [...path, toRemove] })
+      return true
+    }
+  }
+
+  // Step 2 — insert missing (count < min)
+  for (const def of constrained) {
+    const min = def.constraints?.min
+    if (min === undefined) continue
+    const fullType = `${parentType}/${def.type}`
+    const count = childIndicesOfType(node, fullType).length
+    if (count < min) {
+      const insertAt = idealIndexForChildType(node, childDefs, def)
+      Transforms.insertNodes(editor, placeholderForChild(def, fullType), {
+        at: [...path, insertAt]
+      })
+      return true
+    }
+  }
+
+  // Step 3 — reorder mispositioned children
+  // Each child gets an "expected rank" from its type's index in childDefs.
+  // Unknown types get Infinity (we don't reorder them — out of scope for v1).
+  const rankOfType = new Map<string, number>()
+  childDefs.forEach((def, idx) => {
+    if (def.type) rankOfType.set(`${parentType}/${def.type}`, idx)
+  })
+
+  const ranks = node.children.map((c) =>
+    Element.isElement(c) ? rankOfType.get(c.type) ?? Infinity : Infinity
+  )
+
+  for (let i = 1; i < ranks.length; i++) {
+    if (ranks[i] < ranks[i - 1]) {
+      // Find where this child belongs: before the first sibling with rank >= ranks[i]
+      let target = 0
+      for (let j = 0; j < i; j++) {
+        if (ranks[j] >= ranks[i]) {
+          target = j
+          break
+        }
+        target = j + 1
+      }
+      Transforms.moveNodes(editor, {
+        at: [...path, i],
+        to: [...path, target]
+      })
+      return true
+    }
+  }
+
+  return false
+}
+
+function childIndicesOfType(parent: Element, fullType: string): number[] {
+  const out: number[] = []
+  for (let i = 0; i < parent.children.length; i++) {
+    const c = parent.children[i]
+    if (Element.isElement(c) && c.type === fullType) out.push(i)
+  }
+  return out
+}
+
+/**
+ * Ideal index for a missing child of `def`: one past the last DOM child whose
+ * type has a smaller rank (earlier in the parent's `children` array), or 0.
+ */
+function idealIndexForChildType(
+  parent: Element,
+  childDefs: ChildComponentEntry[],
+  def: ChildComponentEntry
+): number {
+  const parentTypeToRank = new Map<string | undefined, number>()
+  childDefs.forEach((d, i) => parentTypeToRank.set(d.type, i))
+  const targetRank = parentTypeToRank.get(def.type) ?? 0
+
+  let idx = 0
+  for (let i = 0; i < parent.children.length; i++) {
+    const c = parent.children[i]
+    if (!Element.isElement(c)) continue
+    // Full type is `${parentType}/${childType}` but here we only know the full type on children.
+    // Extract the short suffix by trying each childDef.
+    const rank = rankForChildNode(c.type, childDefs)
+    if (rank < targetRank) idx = i + 1
+  }
+  return idx
+}
+
+function rankForChildNode(fullChildType: string, childDefs: ChildComponentEntry[]): number {
+  for (let i = 0; i < childDefs.length; i++) {
+    const def = childDefs[i]
+    if (def.type && fullChildType.endsWith(`/${def.type}`)) return i
+  }
+  return Infinity
+}
+
+function placeholderForChild(def: ChildComponentEntry, fullType: string): Descendant {
+  const base = {
+    id: crypto.randomUUID(),
+    type: fullType,
+    children: [{ text: '' }]
+  }
+  switch (def.class) {
+    case 'void':
+      return { ...base, class: 'void' } as unknown as Descendant
+    case 'block':
+      return { ...base, class: 'block' } as unknown as Descendant
+    case 'text':
+      return { ...base, class: 'text', properties: {} } as unknown as Descendant
+    default:
+      // Any other class (e.g. an invalid plugin config) falls back to a text
+      // placeholder — the least surprising, least breakable shape for Slate.
+      return { ...base, class: 'text', properties: {} } as unknown as Descendant
+  }
+}
+

--- a/tests/childConstraints.test.tsx
+++ b/tests/childConstraints.test.tsx
@@ -1,0 +1,614 @@
+import { describe, test, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSlateStatic } from 'slate-react'
+import { type PropsWithChildren } from 'react'
+import type { Descendant, Editor, Element } from 'slate'
+import { Transforms, Editor as SlateEditor } from 'slate'
+import { TextbitRoot } from '../lib/components/TextbitRoot'
+import { TextbitEditable } from '../lib/components/TextbitEditable/TextbitEditable'
+import type { PluginDefinition, ComponentEntry, ChildComponentEntry } from '../lib/types'
+
+// ---------------------------------------------------------------------------
+// A test-only "image" plugin with declarative child constraints matching the
+// real Image plugin's shape: a void 'content' child and a text 'caption' child,
+// both min:1, max:1 (form-field semantics). No custom normalizer — all behavior
+// should come from the declarative constraints alone.
+// ---------------------------------------------------------------------------
+
+const testImagePlugin: PluginDefinition = {
+  class: 'block',
+  name: 'test/image',
+  componentEntry: {
+    class: 'block',
+    component: ({ children, attributes }) => <figure {...attributes}>{children}</figure>,
+    children: [
+      {
+        type: 'content',
+        class: 'void',
+        component: ({ attributes, children }) => (
+          <div contentEditable={false} {...attributes}>content{children}</div>
+        ),
+        constraints: { min: 1, max: 1 }
+      },
+      {
+        type: 'caption',
+        class: 'text',
+        component: ({ attributes, children }) => <figcaption {...attributes}>{children}</figcaption>,
+        constraints: { allowBreak: false, min: 1, max: 1 }
+      }
+    ]
+  }
+}
+
+// A plugin with max:3 body children — to exercise the "not always max:1" path
+const testMultiBodyPlugin: PluginDefinition = {
+  class: 'block',
+  name: 'test/multi',
+  componentEntry: {
+    class: 'block',
+    component: ({ children, attributes }) => <div {...attributes}>{children}</div>,
+    children: [
+      {
+        type: 'body',
+        class: 'text',
+        component: ({ attributes, children }) => <p {...attributes}>{children}</p>,
+        constraints: { min: 1, max: 3 }
+      }
+    ]
+  }
+}
+
+// A plugin with min:2, max:5 to exercise insertion beyond a single placeholder
+const testMinTwoPlugin: PluginDefinition = {
+  class: 'block',
+  name: 'test/mintwo',
+  componentEntry: {
+    class: 'block',
+    component: ({ children, attributes }) => <div {...attributes}>{children}</div>,
+    children: [
+      {
+        type: 'body',
+        class: 'text',
+        component: ({ attributes, children }) => <p {...attributes}>{children}</p>,
+        constraints: { min: 2, max: 5 }
+      }
+    ]
+  }
+}
+
+// A plugin whose child has ONLY max:1 — isolates the max enforcement from
+// allowBreak:false. Lets us prove that max alone blocks Enter.
+const testMaxOnlyPlugin: PluginDefinition = {
+  class: 'block',
+  name: 'test/maxonly',
+  componentEntry: {
+    class: 'block',
+    component: ({ children, attributes }) => <div {...attributes}>{children}</div>,
+    children: [
+      {
+        type: 'slot',
+        class: 'text',
+        component: ({ attributes, children }) => <p {...attributes}>{children}</p>,
+        constraints: { max: 1 } // NO allowBreak — max must do the work alone
+      }
+    ]
+  }
+}
+
+// A factory that builds a plugin with both declarative constraints AND a
+// custom normalizeNode. The spy lets a test observe that the custom
+// normalizer is called AFTER declarative enforcement converges.
+function makeImageWithSpyPlugin(spy: () => void): PluginDefinition {
+  return {
+    class: 'block',
+    name: 'test/spyimage',
+    componentEntry: {
+      class: 'block',
+      component: ({ children, attributes }) => <figure {...attributes}>{children}</figure>,
+      constraints: {
+        normalizeNode: () => {
+          spy()
+          return undefined
+        }
+      },
+      children: [
+        {
+          type: 'slot',
+          class: 'text',
+          component: ({ attributes, children }) => <p {...attributes}>{children}</p>,
+          constraints: { min: 1, max: 1 }
+        }
+      ]
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture content
+// ---------------------------------------------------------------------------
+
+function imageBlock(id: string, caption: string): Descendant {
+  return {
+    type: 'test/image',
+    id,
+    class: 'block',
+    children: [
+      {
+        id: `${id}-content`,
+        type: 'test/image/content',
+        class: 'void',
+        children: [{ text: '' }]
+      },
+      {
+        id: `${id}-caption`,
+        type: 'test/image/caption',
+        class: 'text',
+        properties: {},
+        children: [{ text: caption }]
+      }
+    ]
+  } as Descendant
+}
+
+function multiBodyBlock(id: string, bodies: string[]): Descendant {
+  return {
+    type: 'test/multi',
+    id,
+    class: 'block',
+    children: bodies.map((text, i) => ({
+      id: `${id}-body-${i}`,
+      type: 'test/multi/body',
+      class: 'text',
+      properties: {},
+      children: [{ text }]
+    }))
+  } as Descendant
+}
+
+function makeEditor(content: Descendant[], plugins: PluginDefinition[] = [testImagePlugin]): Editor {
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <TextbitRoot value={content} onChange={() => { }} plugins={plugins}>
+        <TextbitEditable>{children}</TextbitEditable>
+      </TextbitRoot>
+    )
+  }
+  const { result: { current: editor } } = renderHook(() => useSlateStatic(), { wrapper: Wrapper })
+  vi.spyOn(editor, 'onChange').mockImplementation(() => { })
+  // Force normalization since Slate's initial value does not always normalize in tests.
+  SlateEditor.normalize(editor, { force: true })
+  return editor
+}
+
+// ---------------------------------------------------------------------------
+// Normalizer — excess (count > max) is trimmed
+// ---------------------------------------------------------------------------
+
+describe('child constraints — normalizer (excess)', () => {
+  test('removes excess children beyond max', () => {
+    const content = [
+      {
+        type: 'test/image',
+        id: 'img-1',
+        class: 'block',
+        children: [
+          { id: 'c1', type: 'test/image/content', class: 'void', children: [{ text: '' }] },
+          { id: 'cap1', type: 'test/image/caption', class: 'text', properties: {}, children: [{ text: 'first' }] },
+          { id: 'cap2', type: 'test/image/caption', class: 'text', properties: {}, children: [{ text: 'extra' }] }
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content)
+
+    // The editor normalizes on construction; the excess caption is removed.
+    const img = editor.children[0] as Element
+    const captions = img.children.filter(
+      (c) => (c as Element).type === 'test/image/caption'
+    )
+    expect(captions).toHaveLength(1)
+    expect((captions[0] as Element).children).toMatchObject([{ text: 'first' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Normalizer — missing (count < min) inserts placeholder; parent never removed
+// ---------------------------------------------------------------------------
+
+describe('child constraints — normalizer (missing)', () => {
+  test('inserts missing text child with min:1 (form-field behavior)', () => {
+    const content = [
+      {
+        type: 'test/image',
+        id: 'img-1',
+        class: 'block',
+        children: [
+          { id: 'c1', type: 'test/image/content', class: 'void', children: [{ text: '' }] }
+          // caption missing
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content)
+
+    const img = editor.children[0] as Element
+    const captions = img.children.filter(
+      (c) => (c as Element).type === 'test/image/caption'
+    )
+    expect(captions).toHaveLength(1)
+    expect((captions[0] as Element).class).toBe('text')
+  })
+
+  test('inserts missing void child with min:1 — parent is never removed', () => {
+    const content = [
+      {
+        type: 'test/image',
+        id: 'img-1',
+        class: 'block',
+        children: [
+          // content missing
+          { id: 'cap1', type: 'test/image/caption', class: 'text', properties: {}, children: [{ text: 'hello' }] }
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content)
+
+    // Parent must still exist
+    expect(editor.children).toHaveLength(1)
+    const img = editor.children[0] as Element
+    expect(img.type).toBe('test/image')
+
+    const contents = img.children.filter(
+      (c) => (c as Element).type === 'test/image/content'
+    )
+    expect(contents).toHaveLength(1)
+    expect((contents[0] as Element).class).toBe('void')
+  })
+
+  test('re-inserts a deleted min:1 caption after user removes it', () => {
+    const editor = makeEditor([imageBlock('img-1', 'hello')])
+
+    // Delete the caption element directly (simulating a hard delete)
+    Transforms.removeNodes(editor, { at: [0, 1] })
+
+    // Normalizer should have re-inserted the caption
+    const img = editor.children[0] as Element
+    const captions = img.children.filter(
+      (c) => (c as Element).type === 'test/image/caption'
+    )
+    expect(captions).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Normalizer — ordering
+// ---------------------------------------------------------------------------
+
+describe('child constraints — normalizer (ordering)', () => {
+  test('reorders children to match children-array order', () => {
+    const content = [
+      {
+        type: 'test/image',
+        id: 'img-1',
+        class: 'block',
+        children: [
+          // caption appears before content — wrong order
+          { id: 'cap1', type: 'test/image/caption', class: 'text', properties: {}, children: [{ text: 'hello' }] },
+          { id: 'c1', type: 'test/image/content', class: 'void', children: [{ text: '' }] }
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content)
+
+    const img = editor.children[0] as Element
+    expect((img.children[0] as Element).type).toBe('test/image/content')
+    expect((img.children[1] as Element).type).toBe('test/image/caption')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Normalizer — no constraints defined → no interference
+// ---------------------------------------------------------------------------
+
+describe('child constraints — no constraints means no interference', () => {
+  test('top-level core/text paragraphs are unaffected', () => {
+    const content: Descendant[] = [
+      {
+        type: 'core/text',
+        id: 'p1',
+        class: 'text',
+        properties: {},
+        children: [{ text: 'hello' }]
+      }
+    ]
+    const editor = makeEditor(content, [])
+
+    expect(editor.children).toHaveLength(1)
+    expect((editor.children[0] as Element).type).toBe('core/text')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Break prevention — max: 1 at count 1 blocks Enter
+// ---------------------------------------------------------------------------
+
+describe('child constraints — break prevention', () => {
+  test('Enter inside max:1 child does not split (count would exceed max)', () => {
+    const editor = makeEditor([imageBlock('img-1', 'Before caption')])
+    // Place cursor in middle of the caption text
+    Transforms.select(editor, {
+      anchor: { path: [0, 1, 0], offset: 6 },
+      focus: { path: [0, 1, 0], offset: 6 }
+    })
+
+    editor.insertBreak()
+
+    const img = editor.children[0] as Element
+    const captions = img.children.filter(
+      (c) => (c as Element).type === 'test/image/caption'
+    )
+    // Still exactly one caption — Enter did not split
+    expect(captions).toHaveLength(1)
+  })
+
+  test('Enter inside max:3 child at count 2 is allowed', () => {
+    const editor = makeEditor(
+      [multiBodyBlock('m-1', ['A', 'B'])],
+      [testMultiBodyPlugin]
+    )
+    // Place cursor at end of first body
+    Transforms.select(editor, SlateEditor.end(editor, [0, 0]))
+
+    editor.insertBreak()
+
+    const block = editor.children[0] as Element
+    const bodies = block.children.filter(
+      (c) => (c as Element).type === 'test/multi/body'
+    )
+    // Split succeeded — now 3 bodies
+    expect(bodies).toHaveLength(3)
+  })
+
+  test('Enter inside max:3 child at count 3 is blocked', () => {
+    const editor = makeEditor(
+      [multiBodyBlock('m-1', ['A', 'B', 'C'])],
+      [testMultiBodyPlugin]
+    )
+    Transforms.select(editor, SlateEditor.end(editor, [0, 0]))
+
+    editor.insertBreak()
+
+    const block = editor.children[0] as Element
+    const bodies = block.children.filter(
+      (c) => (c as Element).type === 'test/multi/body'
+    )
+    expect(bodies).toHaveLength(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Paste — flatten block fragment inside child text element
+// ---------------------------------------------------------------------------
+
+describe('child constraints — paste flattening', () => {
+  test('pasting a block fragment into a caption flattens to plain text', () => {
+    const editor = makeEditor([imageBlock('img-1', 'start ')])
+    Transforms.select(editor, SlateEditor.end(editor, [0, 1]))
+
+    // Simulate pasting another image block
+    const fragment = [imageBlock('pasted', 'PASTED CAPTION')]
+    editor.insertFragment(fragment)
+
+    const img = editor.children[0] as Element
+    // Still just the one top-level block — no siblings inserted
+    expect(editor.children).toHaveLength(1)
+
+    // Caption text now contains the flattened text
+    const caption = img.children[1] as Element
+    const captionText = (caption.children[0] as { text: string }).text
+    expect(captionText).toContain('start ')
+    expect(captionText).toContain('PASTED CAPTION')
+  })
+
+  test('pasting a block fragment into a top-level paragraph still splits (existing behavior)', () => {
+    const content: Descendant[] = [
+      { type: 'core/text', id: 'p1', class: 'text', properties: {}, children: [{ text: 'BeforeAfter' }] }
+    ]
+    const editor = makeEditor(content, [])
+
+    Transforms.select(editor, {
+      anchor: { path: [0, 0], offset: 6 },
+      focus: { path: [0, 0], offset: 6 }
+    })
+
+    const fragment: Descendant[] = [
+      {
+        type: 'core/text',
+        class: 'text',
+        id: 'block',
+        properties: {},
+        children: [{ text: 'MID' }]
+      },
+      {
+        type: 'core/text',
+        class: 'text',
+        id: 'block-x',
+        properties: {},
+        children: [{ text: 'X' }]
+      } as Descendant
+    ]
+    // Force-mixed fragment by making one non-text
+    ;(fragment[1] as unknown as { class: string }).class = 'block'
+
+    editor.insertFragment(fragment)
+
+    // Top-level paragraph was split and blocks inserted between halves
+    expect(editor.children.length).toBeGreaterThan(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GAP COVERAGE — intent-level cases not covered by the happy-path tests above
+// ---------------------------------------------------------------------------
+
+describe('child constraints — intent coverage', () => {
+  // Gap 1: min > 1 path — inserts multiple placeholders to reach min
+  test('min: 2 inserts a second placeholder when only one child exists', () => {
+    const content = [
+      {
+        type: 'test/mintwo',
+        id: 'mt-1',
+        class: 'block',
+        children: [
+          { id: 'b1', type: 'test/mintwo/body', class: 'text', properties: {},
+            children: [{ text: 'only one' }] }
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content, [testMinTwoPlugin])
+
+    const block = editor.children[0] as Element
+    const bodies = block.children.filter(
+      (c) => (c as Element).type === 'test/mintwo/body'
+    )
+    expect(bodies).toHaveLength(2)
+  })
+
+  // Gap 2: deleting above min does NOT trigger re-insert
+  test('removing a body above min (3 → 2, min is 1) leaves count at 2', () => {
+    const editor = makeEditor(
+      [multiBodyBlock('m-1', ['A', 'B', 'C'])],
+      [testMultiBodyPlugin]
+    )
+
+    // Remove the middle body — count goes from 3 to 2, still >= min (1)
+    Transforms.removeNodes(editor, { at: [0, 1] })
+
+    const block = editor.children[0] as Element
+    const bodies = block.children.filter(
+      (c) => (c as Element).type === 'test/multi/body'
+    )
+    expect(bodies).toHaveLength(2)
+    // Remaining two should be A and C (the normalizer should NOT re-insert B)
+    expect((bodies[0] as Element).children).toMatchObject([{ text: 'A' }])
+    expect((bodies[1] as Element).children).toMatchObject([{ text: 'C' }])
+  })
+
+  // Gap 3: max alone (without allowBreak:false) blocks Enter
+  test('max: 1 alone (no allowBreak) blocks Enter at count 1', () => {
+    const content = [
+      {
+        type: 'test/maxonly',
+        id: 'mo-1',
+        class: 'block',
+        children: [
+          { id: 's1', type: 'test/maxonly/slot', class: 'text', properties: {},
+            children: [{ text: 'some text' }] }
+        ]
+      } as Descendant
+    ]
+    const editor = makeEditor(content, [testMaxOnlyPlugin])
+
+    // Place cursor in the middle of the slot text
+    Transforms.select(editor, {
+      anchor: { path: [0, 0, 0], offset: 4 },
+      focus: { path: [0, 0, 0], offset: 4 }
+    })
+
+    editor.insertBreak()
+
+    const block = editor.children[0] as Element
+    const slots = block.children.filter(
+      (c) => (c as Element).type === 'test/maxonly/slot'
+    )
+    // max:1 alone must have blocked the split
+    expect(slots).toHaveLength(1)
+  })
+
+  // Gap 4: plugin's custom normalizeNode still runs after declarative enforcement
+  test("custom normalizeNode is called after declarative enforcement converges", () => {
+    const spy = vi.fn()
+    const plugin = makeImageWithSpyPlugin(spy)
+
+    // Content is invalid (missing the required slot child) so the declarative
+    // enforcement must run first to insert it; afterwards the custom
+    // normalizeNode must still be called on the parent.
+    const content = [
+      {
+        type: 'test/spyimage',
+        id: 'si-1',
+        class: 'block',
+        children: []
+      } as Descendant
+    ]
+    makeEditor(content, [plugin])
+
+    // Custom normalizeNode must have been called at least once for the parent
+    // after the declarative insertion converged.
+    expect(spy).toHaveBeenCalled()
+  })
+
+  // Gap 5: text-only fragment into a child text element goes through the normal
+  // insertFragment path — NOT the block-fragment flatten path (which calls
+  // editor.insertText and strips marks/structure). We assert specifically that
+  // the flatten path was not taken; the actual merge behaviour for text-only
+  // fragments is owned by Slate's default insertFragment and is out of scope.
+  test('text-only fragment pasted into a caption does NOT go through the flatten path', () => {
+    const editor = makeEditor([imageBlock('img-1', 'caption: ')])
+    Transforms.select(editor, SlateEditor.end(editor, [0, 1]))
+
+    // The flatten path would call editor.insertText(flattenedString). The
+    // normal text-fragment path never does.
+    const insertTextSpy = vi.spyOn(editor, 'insertText')
+
+    const textFragment: Descendant[] = [
+      {
+        type: 'core/text',
+        class: 'text',
+        id: 'f1',
+        properties: {},
+        children: [{ text: 'appended' }]
+      }
+    ]
+    editor.insertFragment(textFragment)
+
+    // Flatten path was NOT used.
+    expect(insertTextSpy).not.toHaveBeenCalled()
+
+    // And we still have exactly one caption (no siblings inserted at block level)
+    const img = editor.children[0] as Element
+    const captions = img.children.filter(
+      (c) => (c as Element).type === 'test/image/caption'
+    )
+    expect(captions).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Gap 6 — type-level enforcement
+//
+// These declarations are never executed; they exist only so that TypeScript's
+// `noEmit` check (`npm run tsc`) fails if someone weakens the type system so
+// that `min` / `max` become accepted on a top-level `ComponentEntry`. The
+// tuple wrappers `[A] extends [B]` prevent distributive conditional types
+// from masking a regression (e.g. union `'FAIL' | 'OK'` being assignable
+// from `'OK'`).
+// ---------------------------------------------------------------------------
+
+// The declared field type of `min` / `max` on a top-level `constraints`,
+// stripped of its automatic `undefined` from the optional marker.
+type _TopLevelMinField = Exclude<NonNullable<ComponentEntry['constraints']>['min'], undefined>
+type _TopLevelMaxField = Exclude<NonNullable<ComponentEntry['constraints']>['max'], undefined>
+
+// If the top-level field type ever becomes `number`, these assertions flip
+// to 'FAIL' and the `const` assignments below stop typechecking.
+type _AssertTopLevelMinIsNotNumber = [number] extends [_TopLevelMinField] ? 'FAIL' : 'OK'
+type _AssertTopLevelMaxIsNotNumber = [number] extends [_TopLevelMaxField] ? 'FAIL' : 'OK'
+const _probeTopMin: _AssertTopLevelMinIsNotNumber = 'OK'
+const _probeTopMax: _AssertTopLevelMaxIsNotNumber = 'OK'
+void _probeTopMin
+void _probeTopMax
+
+// Corresponding positive check: child entries still accept a number.
+type _ChildMinField = Exclude<NonNullable<ChildComponentEntry['constraints']>['min'], undefined>
+type _AssertChildAcceptsNumber = [number] extends [_ChildMinField] ? 'OK' : 'FAIL'
+const _probeChild: _AssertChildAcceptsNumber = 'OK'
+void _probeChild


### PR DESCRIPTION
This will allow us to remove normalizers from several plugins and make it simpler to create plugins in the future.