### PR TITLE
fix(placeholder): emit data-slate-placeholder attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,21 @@ Set the property on the editor root or any ancestor:
 }
 ```
 
+#### Placeholder
+
+The empty-leaf placeholder (shown when `placeholder` is set and the editor/text node is empty) renders with `data-slate-placeholder="true"`, matching slate-react's convention.
+
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-slate-placeholder` | `"true"` | Present on the placeholder element when an empty editor/text node displays placeholder text. |
+
+```css
+[data-slate-placeholder] {
+  font-style: italic;
+  color: #94a3b8;
+}
+```
+
 #### Drag and Drop
 
 ```css

--- a/lib/components/Element/LeafElement.tsx
+++ b/lib/components/Element/LeafElement.tsx
@@ -120,6 +120,7 @@ function Placeholder({ value, style, ref }: { value: string, style: CSSPropertie
   return (
     <div
       ref={ref}
+      data-slate-placeholder={true}
       style={{
         ...style,
         opacity: 0.333,


### PR DESCRIPTION
Restores the data-slate-placeholder="true" attribute on the empty-leaf placeholder div so consumers can target empty editors with CSS. Matches slate-react's default placeholder convention.