### PR TITLE
Fix/faulty element wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,21 +990,6 @@ Every rendered element wrapper carries the element's type as a data attribute, e
 }
 ```
 
-#### Placeholder
-
-The empty-leaf placeholder (shown when `placeholder` is set and the editor or text node is empty) is rendered with `data-slate-placeholder="true"`, matching slate-react's convention.
-
-| Attribute | Values | Description |
-|-----------|--------|-------------|
-| `data-slate-placeholder` | `"true"` | Present on the placeholder element when an empty editor/text node displays placeholder text. |
-
-```css
-[data-slate-placeholder] {
-  font-style: italic;
-  color: #94a3b8;
-}
-```
-
 ### Spelling Errors
 
 Spelling errors are rendered with data attributes for custom styling:

--- a/README.md
+++ b/README.md
@@ -1474,13 +1474,13 @@ function ImageComponent({ element }: TBComponentProps) {
 
 ### Custom Root Elements (`asOwnElement`)
 
-By default, Textbit wraps each plugin component in a `<div>` so framework attributes (`data-id`, `data-type`, slate-react's `data-slate-node`, etc.) reliably reach the DOM. When the structural HTML tag matters — e.g. a `<tr>` inside a `<table>`, or an `<li>` inside a `<ul>` — set `asOwnElement: true` on the `componentEntry` and have the component spread `attributes` and attach `ref` onto its own root node.
+By default, Textbit wraps each plugin component in a `<div>` so framework attributes (`data-id`, `data-type`, slate-react's `data-slate-node`, etc.) reliably reach the DOM. When the structural HTML tag matters — e.g. a `<tr>` inside a `<table>`, or an `<li>` inside a `<ul>` — set `asOwnElement: true` on the `componentEntry` and spread `attributes` onto the component's root node.
 
 ```tsx
 import type { TBComponentProps } from '@ttab/textbit'
 
-export const TableRow = ({ children, attributes, ref }: TBComponentProps<HTMLTableRowElement>) => (
-  <tr {...attributes} ref={ref}>{children}</tr>
+export const TableRow = ({ children, attributes }: TBComponentProps<HTMLTableRowElement>) => (
+  <tr {...attributes}>{children}</tr>
 )
 
 TableRow.displayName = 'TableRow'
@@ -1494,7 +1494,7 @@ TableRow.displayName = 'TableRow'
 }
 ```
 
-When `asOwnElement` is true, the component is responsible for forwarding `attributes` (which includes the framework's `data-id`, `data-type`, `lang`, plus slate-react's `data-slate-node`) and `ref` onto its root DOM element. Failing to do so will break selection mapping for that element.
+When `asOwnElement` is true, the component is responsible for spreading `attributes` onto its root DOM element. `attributes` carries the framework's `data-id`, `data-type`, and `lang`, plus slate-react's `data-slate-node` and `ref`. Failing to spread them will break selection mapping for that element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1494,7 +1494,7 @@ TableRow.displayName = 'TableRow'
 }
 ```
 
-When `asOwnElement` is true, the component is responsible for forwarding `attributes` (which includes the framework's `data-id`, `data-type`, `lang`, `className`, plus slate-react's `data-slate-node`) and `ref` onto its root DOM element. Failing to do so will break selection mapping for that element.
+When `asOwnElement` is true, the component is responsible for forwarding `attributes` (which includes the framework's `data-id`, `data-type`, `lang`, plus slate-react's `data-slate-node`) and `ref` onto its root DOM element. Failing to do so will break selection mapping for that element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -970,6 +970,41 @@ The empty-leaf placeholder (shown when `placeholder` is set and the editor/text 
 }
 ```
 
+#### Element Type
+
+Every rendered element wrapper carries the element's type as a data attribute, enabling consumers to target a specific block or any of its named child slots from CSS without parsing classnames.
+
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-type` | `string` | The element's `type` (e.g. `core/image`, `core/image/caption`). Present on both top-level block wrappers and child element wrappers. |
+
+```css
+/* Style the byline field of a TTVisual block */
+[data-type="tt/visual/byline"] {
+  font-style: italic;
+}
+
+/* Combine with slate-react's marker to target only the editable region */
+[data-type="tt/visual/byline"] [data-slate-leaf] {
+  background: #fafafa;
+}
+```
+
+#### Placeholder
+
+The empty-leaf placeholder (shown when `placeholder` is set and the editor or text node is empty) is rendered with `data-slate-placeholder="true"`, matching slate-react's convention.
+
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-slate-placeholder` | `"true"` | Present on the placeholder element when an empty editor/text node displays placeholder text. |
+
+```css
+[data-slate-placeholder] {
+  font-style: italic;
+  color: #94a3b8;
+}
+```
+
 ### Spelling Errors
 
 Spelling errors are rendered with data attributes for custom styling:
@@ -1437,20 +1472,29 @@ function ImageComponent({ element }: TBComponentProps) {
 }
 ```
 
-### Forwarding Refs for HTML Elements
+### Custom Root Elements (`asOwnElement`)
 
-If your component wants to use a specific wrapper HTML element (like `<tr>`, `<td>`, etc.), use `ref`:
+By default, Textbit wraps each plugin component in a `<div>` so framework attributes (`data-id`, `data-type`, slate-react's `data-slate-node`, etc.) reliably reach the DOM. When the structural HTML tag matters — e.g. a `<tr>` inside a `<table>`, or an `<li>` inside a `<ul>` — set `asOwnElement: true` on the `componentEntry` and have the component spread `attributes` and attach `ref` onto its own root node.
 
 ```tsx
 import type { TBComponentProps } from '@ttab/textbit'
 
-export const TableRow = ({ children, ref }: TBComponentProps<HTMLTableRowElement>) => (
-  <tr ref={ref}>{children}</tr>
+export const TableRow = ({ children, attributes, ref }: TBComponentProps<HTMLTableRowElement>) => (
+  <tr {...attributes} ref={ref}>{children}</tr>
 )
 
 TableRow.displayName = 'TableRow'
 
+// In the plugin definition:
+{
+  type: 'row',
+  class: 'block',
+  component: TableRow,
+  asOwnElement: true
+}
 ```
+
+When `asOwnElement` is true, the component is responsible for forwarding `attributes` (which includes the framework's `data-id`, `data-type`, `lang`, `className`, plus slate-react's `data-slate-node`) and `ref` onto its root DOM element. Failing to do so will break selection mapping for that element.
 
 ---
 

--- a/lib/components/Element/ChildElement.tsx
+++ b/lib/components/Element/ChildElement.tsx
@@ -29,7 +29,6 @@ export function ChildElement({
         lang={lang}
         data-id={element.id}
         data-type={element.type}
-        className='child'
         {...attributes}
       >
         <Component element={element} rootNode={rootNode} options={options} editor={editor}>
@@ -48,8 +47,7 @@ export function ChildElement({
     ...slateAttributes,
     lang,
     'data-id': element.id,
-    'data-type': element.type,
-    className: 'child'
+    'data-type': element.type
   }
 
   return (

--- a/lib/components/Element/ChildElement.tsx
+++ b/lib/components/Element/ChildElement.tsx
@@ -39,12 +39,10 @@ export function ChildElement({
   }
 
   // Opt-in: the plugin component renders as the element itself, owning its
-  // root DOM node. It must spread `attributes` and attach `ref` onto that
-  // root. Used when the structural HTML tag matters (e.g. <tr> inside
-  // <table>, <li> inside <ul>).
-  const { ref, ...slateAttributes } = attributes
+  // root DOM node. It must spread `attributes` onto that root. Used when the
+  // structural HTML tag matters (e.g. <tr> inside <table>, <li> inside <ul>).
   const decoratedAttributes = {
-    ...slateAttributes,
+    ...attributes,
     lang,
     'data-id': element.id,
     'data-type': element.type
@@ -57,7 +55,6 @@ export function ChildElement({
       rootNode={rootNode}
       options={options}
       editor={editor}
-      ref={ref}
     >
       {children}
     </Component>

--- a/lib/components/Element/ChildElement.tsx
+++ b/lib/components/Element/ChildElement.tsx
@@ -17,13 +17,13 @@ export function ChildElement({
   options
 }: ChildElementProps) {
   const editor = useSlateStatic()
-  const { component: Component } = entry
   const lang = element.lang || editor.lang
 
   // Default: wrap the plugin component in a <div> so framework attributes
   // (data-id, data-type, slate-react's data-slate-node, ref) reliably reach
   // the DOM regardless of what the plugin component renders.
   if (!entry.asOwnElement) {
+    const { component: Component } = entry
     return (
       <div
         lang={lang}
@@ -41,6 +41,7 @@ export function ChildElement({
   // Opt-in: the plugin component renders as the element itself, owning its
   // root DOM node. It must spread `attributes` onto that root. Used when the
   // structural HTML tag matters (e.g. <tr> inside <table>, <li> inside <ul>).
+  const { component: Component } = entry
   const decoratedAttributes = {
     ...attributes,
     lang,

--- a/lib/components/Element/ChildElement.tsx
+++ b/lib/components/Element/ChildElement.tsx
@@ -1,7 +1,3 @@
-import {
-  isValidElement,
-  cloneElement
-} from 'react'
 import { Element } from 'slate'
 import { useSlateStatic, type RenderElementProps } from 'slate-react'
 import type { ChildComponentEntry } from '../../types'
@@ -24,45 +20,48 @@ export function ChildElement({
   const { component: Component } = entry
   const lang = element.lang || editor.lang
 
-  // If there's a ref, the component expects to handle attributes itself (no wrapper)
-  if (attributes.ref) {
-    const childElement = (
-      <Component
-        element={element}
-        attributes={attributes}
-        children={children}
-        rootNode={rootNode}
-        options={options}
-        editor={editor}
-        ref={attributes.ref}
-      />
+  // Default: wrap the plugin component in a <div> so framework attributes
+  // (data-id, data-type, slate-react's data-slate-node, ref) reliably reach
+  // the DOM regardless of what the plugin component renders.
+  if (!entry.asOwnElement) {
+    return (
+      <div
+        lang={lang}
+        data-id={element.id}
+        data-type={element.type}
+        className='child'
+        {...attributes}
+      >
+        <Component element={element} rootNode={rootNode} options={options} editor={editor}>
+          {children}
+        </Component>
+      </div>
     )
-
-    if (!childElement || !isValidElement(childElement)) {
-      console.error('Child component must return a valid React element')
-      return <></>
-    }
-
-    // Clone and merge attributes directly into the element
-    return cloneElement(childElement, {
-      lang,
-      'data-id': element.id,
-      className: ['child', (childElement.props as React.HTMLAttributes<HTMLDivElement>)?.className].filter(Boolean).join(' '),
-      ...attributes
-    } as React.HTMLAttributes<HTMLDivElement>)
   }
 
-  // No ref means regular component - use wrapper div
+  // Opt-in: the plugin component renders as the element itself, owning its
+  // root DOM node. It must spread `attributes` and attach `ref` onto that
+  // root. Used when the structural HTML tag matters (e.g. <tr> inside
+  // <table>, <li> inside <ul>).
+  const { ref, ...slateAttributes } = attributes
+  const decoratedAttributes = {
+    ...slateAttributes,
+    lang,
+    'data-id': element.id,
+    'data-type': element.type,
+    className: 'child'
+  }
+
   return (
-    <div
-      lang={lang}
-      data-id={element.id}
-      className='child'
-      {...attributes}
+    <Component
+      element={element}
+      attributes={decoratedAttributes}
+      rootNode={rootNode}
+      options={options}
+      editor={editor}
+      ref={ref}
     >
-      <Component element={element} rootNode={rootNode} options={options} editor={editor}>
-        {children}
-      </Component>
-    </div>
+      {children}
+    </Component>
   )
 }

--- a/lib/components/Element/InlineElement.tsx
+++ b/lib/components/Element/InlineElement.tsx
@@ -16,7 +16,7 @@ export function InlineElement({ attributes, children, element, entry, options }:
   const editor = useSlateStatic()
 
   return (
-    <span className={`inline ${entry.type}`} data-id={element.id} {...attributes}>
+    <span className={`inline ${entry.type}`} data-id={element.id} data-type={element.type} {...attributes}>
       <entry.component element={element} options={options} editor={editor}>
         {children}
       </entry.component>

--- a/lib/components/Element/InlineElement.tsx
+++ b/lib/components/Element/InlineElement.tsx
@@ -14,6 +14,7 @@ interface InlineElementProps extends RenderElementProps {
  */
 export function InlineElement({ attributes, children, element, entry, options }: InlineElementProps) {
   const editor = useSlateStatic()
+  if (entry.asOwnElement) return null
 
   return (
     <span className={`inline ${entry.type}`} data-id={element.id} data-type={element.type} {...attributes}>

--- a/lib/components/Element/ParentElement.tsx
+++ b/lib/components/Element/ParentElement.tsx
@@ -67,6 +67,7 @@ export function ParentElement(renderProps: ParentElementProps) {
       <div
         lang={renderProps.element.lang || editor.lang}
         data-id={element.id}
+        data-type={element.type}
         data-state={dataState}
         {...(isBlockSelected ? { 'data-block-selected': '' } : {})}
         className={`${element.class} ${element.type} ${entry.class} relative group`}

--- a/lib/components/Element/ParentElement.tsx
+++ b/lib/components/Element/ParentElement.tsx
@@ -22,6 +22,7 @@ export function ParentElement(renderProps: ParentElementProps) {
   const adjacentBlock = useAdjacentBlock()
   const blockSelection = useBlockSelection()
   const { element, attributes, entry } = renderProps
+  if (entry.asOwnElement) return null
 
   // Block-level selection: check if this element is within the selected range
   const isBlockSelected = (() => {
@@ -74,7 +75,9 @@ export function ParentElement(renderProps: ParentElementProps) {
         style={{ position: 'relative', ...(isBlockSelected ? { userSelect: 'none' } : {}) }}
         {...attributes}
       >
-        <entry.component {...renderProps} editor={editor} />
+        <entry.component element={element} options={renderProps.options} editor={editor}>
+          {renderProps.children}
+        </entry.component>
         {element.class !== 'text' && element.class !== 'inline' && (
           <div
             contentEditable={false}

--- a/lib/components/Element/UnknownElement.tsx
+++ b/lib/components/Element/UnknownElement.tsx
@@ -13,6 +13,7 @@ export function UnknownElement({ element, attributes, children }: RenderElementP
         contentEditable={false}
         className='textbit-parent textbit-unknown'
         data-id={element.id}
+        data-type={element.type}
         {...attributes}
       >
         <pre style={{ fontSize: '80%' }}>

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -11,6 +11,7 @@ export type {
   ChildComponentEntry as TBChildComponentEntry,
   Component as TBComponent,
   ComponentProps as TBComponentProps,
+  ElementAttributes as TBElementAttributes,
   ToolComponent as TBToolComponent,
   ToolComponentProps as TBToolComponentProps,
   ActionHandlerArgs as TBActionHandlerArgs,

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -12,6 +12,8 @@ export type {
   Component as TBComponent,
   ComponentProps as TBComponentProps,
   ElementAttributes as TBElementAttributes,
+  OwnElementComponent as TBOwnElementComponent,
+  OwnElementComponentProps as TBOwnElementComponentProps,
   ToolComponent as TBToolComponent,
   ToolComponentProps as TBToolComponentProps,
   ActionHandlerArgs as TBActionHandlerArgs,

--- a/lib/types/textbit.ts
+++ b/lib/types/textbit.ts
@@ -3,21 +3,38 @@ import type { RenderElementProps } from 'slate-react'
 import { type NodeEntry, Node, Editor, Element } from 'slate'
 
 /**
+ * @type
+ * Shape of `attributes` provided to plugin components that opt into
+ * `asOwnElement`. Spreading these onto a DOM element of type `T` carries
+ * slate-react's ref and `data-slate-node` along with the framework's
+ * `data-id`, `data-type`, and `lang`.
+ */
+export type ElementAttributes<T extends HTMLElement = HTMLElement> = {
+  'data-slate-node': 'element'
+  'data-slate-inline'?: true
+  'data-slate-void'?: true
+  'data-id'?: string
+  'data-type': string
+  lang?: string
+  dir?: 'rtl'
+  ref: React.Ref<T>
+}
+
+/**
  * @interface
  * Textbit component props.
  *
- * Components that opt into `asOwnElement` should spread `attributes` onto
- * their root DOM node — this carries slate-react's ref and `data-slate-node`
- * along with the framework's `data-id`, `data-type`, and `lang`. Parameterize
- * `T` with the root element's HTML type (e.g. `HTMLTableRowElement`) so the
- * ref carried in `attributes` is correctly typed for that element.
+ * Components that opt into `asOwnElement` receive `attributes` and must
+ * spread them onto their root DOM node. Parameterize `T` with the root
+ * element's HTML type (e.g. `HTMLTableRowElement`) so the ref carried in
+ * `attributes` is correctly typed for that element.
  */
 export interface ComponentProps<T extends HTMLElement = HTMLElement> extends Omit<RenderElementProps, 'attributes'> {
   rootNode?: Element
   options?: Options
   editor: Editor
   children: React.ReactNode
-  attributes?: Record<string, unknown> & { ref?: React.Ref<T> }
+  attributes?: ElementAttributes<T>
 }
 
 /**

--- a/lib/types/textbit.ts
+++ b/lib/types/textbit.ts
@@ -46,6 +46,25 @@ export type Component<T extends HTMLElement = HTMLElement, Props = ComponentProp
 }
 
 /**
+ * @type
+ * Props handed to a plugin component that opts into `asOwnElement: true`.
+ * Identical to `ComponentProps<T>` except `attributes` is non-nullable —
+ * the framework guarantees it when the component owns its root element.
+ */
+export type OwnElementComponentProps<T extends HTMLElement = HTMLElement> =
+  Omit<ComponentProps<T>, 'attributes'> & {
+    attributes: ElementAttributes<T>
+  }
+
+/**
+ * @type
+ * Component for a plugin entry that owns its root DOM element.
+ */
+export type OwnElementComponent<T extends HTMLElement = HTMLElement> = {
+  (props: OwnElementComponentProps<T>): ReactNode
+}
+
+/**
  * @interface
  * Textbit tool component props
  */
@@ -160,8 +179,10 @@ export interface ChildConstraints extends BaseConstraints {
 
 /**
  * Fields common to every component entry, independent of whether it is used
- * as a top-level or child entry.
+ * as a top-level or child entry. `T` is consumed by the union variants of
+ * `ComponentEntry` / `ChildComponentEntry` below to type `component`.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface BaseComponentEntry<T extends HTMLElement = HTMLElement> {
   /** Class of the component, inherited from plugin if not specified. ('leaf' | 'inline' | 'text' | 'textblock' | 'block' | 'void' | 'generic') */
   class: string
@@ -179,17 +200,6 @@ interface BaseComponentEntry<T extends HTMLElement = HTMLElement> {
   /** Placeholder text for an empty text node, optional */
   placeholder?: string | ((type: Element) => React.ReactNode)
 
-  /** Render function for the element, mandatory */
-  component: Component<T>
-
-  /**
-   * When true, the plugin component renders as the element itself, owning
-   * its own root DOM node. The component MUST spread `attributes` onto that
-   * root and attach `ref`. Default: false — the framework wraps the
-   * component in a <div>.
-   */
-  asOwnElement?: boolean
-
   // Children must be able to use any element, not only HTMLElement.
   // Type safety is enforced at the component level through Component<T>.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -197,25 +207,64 @@ interface BaseComponentEntry<T extends HTMLElement = HTMLElement> {
 }
 
 /**
- * @interface
+ * @type
  * A top-level component entry (e.g. the one attached to a PluginDefinition).
- * Accepts every behavior-level constraint but rejects cardinality constraints.
+ * Discriminated on `asOwnElement`:
+ *
+ * - When `asOwnElement` is omitted or `false`, the framework wraps the
+ *   component in a `<div>` and the component receives `ComponentProps<T>`
+ *   (where `attributes` is undefined).
+ * - When `asOwnElement` is `true`, the component renders as the element
+ *   itself and is required to spread `attributes` (now non-nullable) onto
+ *   its root DOM node.
+ *
+ * Accepts every behavior-level constraint but rejects cardinality
+ * constraints (`min`/`max` are only meaningful on child entries).
  */
-export interface ComponentEntry<T extends HTMLElement = HTMLElement> extends BaseComponentEntry<T> {
-  /** Hard constraints for the component */
-  constraints?: TopLevelConstraints
-}
+export type ComponentEntry<T extends HTMLElement = HTMLElement> =
+  | (BaseComponentEntry<T> & {
+      /**
+       * When `false` or omitted, the framework wraps the component in a
+       * `<div>`. Default behavior.
+       */
+      asOwnElement?: false
+      /** Render function for the element, mandatory */
+      component: Component<T>
+      /** Hard constraints for the component */
+      constraints?: TopLevelConstraints
+    })
+  | (BaseComponentEntry<T> & {
+      /**
+       * When `true`, the plugin component renders as the element itself,
+       * owning its root DOM node. The component MUST spread `attributes`
+       * onto that root.
+       */
+      asOwnElement: true
+      /** Render function for the element, mandatory */
+      component: OwnElementComponent<T>
+      /** Hard constraints for the component */
+      constraints?: TopLevelConstraints
+    })
 
 /**
- * @interface
- * A child component entry — an item in a parent's `children` array. Accepts
- * the behavior-level constraints plus `min`/`max` for cardinality within
- * the parent.
+ * @type
+ * A child component entry — an item in a parent's `children` array.
+ * Same `asOwnElement` discrimination as `ComponentEntry`, but with
+ * cardinality constraints (`min`/`max`) available.
  */
-export interface ChildComponentEntry<T extends HTMLElement = HTMLElement> extends BaseComponentEntry<T> {
-  /** Hard constraints for the component, including cardinality in the parent */
-  constraints?: ChildConstraints
-}
+export type ChildComponentEntry<T extends HTMLElement = HTMLElement> =
+  | (BaseComponentEntry<T> & {
+      asOwnElement?: false
+      component: Component<T>
+      /** Hard constraints for the component, including cardinality in the parent */
+      constraints?: ChildConstraints
+    })
+  | (BaseComponentEntry<T> & {
+      asOwnElement: true
+      component: OwnElementComponent<T>
+      /** Hard constraints for the component, including cardinality in the parent */
+      constraints?: ChildConstraints
+    })
 
 
 /**

--- a/lib/types/textbit.ts
+++ b/lib/types/textbit.ts
@@ -1,18 +1,23 @@
-import type { PropsWithChildren, ReactNode, RefObject } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import type { RenderElementProps } from 'slate-react'
 import { type NodeEntry, Node, Editor, Element } from 'slate'
 
 /**
  * @interface
- * Textbit component props
+ * Textbit component props.
+ *
+ * Components that opt into `asOwnElement` should spread `attributes` onto
+ * their root DOM node — this carries slate-react's ref and `data-slate-node`
+ * along with the framework's `data-id`, `data-type`, and `lang`. Parameterize
+ * `T` with the root element's HTML type (e.g. `HTMLTableRowElement`) so the
+ * ref carried in `attributes` is correctly typed for that element.
  */
 export interface ComponentProps<T extends HTMLElement = HTMLElement> extends Omit<RenderElementProps, 'attributes'> {
   rootNode?: Element
   options?: Options
   editor: Editor
   children: React.ReactNode
-  ref?: RefObject<T>
-  attributes?: Record<string, unknown>
+  attributes?: Record<string, unknown> & { ref?: React.Ref<T> }
 }
 
 /**

--- a/lib/types/textbit.ts
+++ b/lib/types/textbit.ts
@@ -160,6 +160,14 @@ interface BaseComponentEntry<T extends HTMLElement = HTMLElement> {
   /** Render function for the element, mandatory */
   component: Component<T>
 
+  /**
+   * When true, the plugin component renders as the element itself, owning
+   * its own root DOM node. The component MUST spread `attributes` onto that
+   * root and attach `ref`. Default: false — the framework wraps the
+   * component in a <div>.
+   */
+  asOwnElement?: boolean
+
   // Children must be able to use any element, not only HTMLElement.
   // Type safety is enforced at the component level through Component<T>.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Re-adding the data attributes for slate node element and data type.

As the wrapper element was not working properly also introducing the asOwnElement property for plugins that needs to render its own element (e.g. table plugin). Additional PR will be opened to fix the table plugin in textbit-plugins)