### PR TITLE
fix(hotkey): render platform-aware hotkey legend

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -94,6 +94,7 @@ export { calculateStats } from './utils/calculateStats'
 export { TextbitEditor } from './utils/textbit-editor'
 export { TextbitElement } from './utils/textbit-element'
 export { TextbitPlugin } from './utils/textbit-plugin'
+export { isMac } from './utils/modifier'
 
 // Re-export slate types to ensure correct overloaded types are exported
 export type {

--- a/lib/utils/modifier.ts
+++ b/lib/utils/modifier.ts
@@ -1,35 +1,56 @@
-export function isMac() {
-  return !!navigator.userAgent.match('Mac OS X')?.length || false
-}
-
-export function modifier(modifier: string) {
-  const mods = modifier.split('+')
-  if (!mods?.length) {
-    return ''
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
   }
 
-  const foo = mods.map((mod) => {
-    switch (mod) {
-      case 'mod':
-        return '⌘'
-      case 'shift':
-        return '⇧'
-      case 'ctrl':
-        return '⌃'
-      case 'alt':
-      case 'option':
-        return '⌥'
-      case 'up':
-        return '↑'
-      case 'down':
-        return '↓'
-      case 'right':
-        return '→'
-      case 'left':
-        return '←'
-      default:
-        return mod
-    }
-  })
-  return foo.join('')
+  const nav = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+  const platform = nav.userAgentData?.platform || nav.platform || nav.userAgent || ''
+  return /\bmac/i.test(platform)
+}
+
+const IS_MAC = isMac()
+
+const SHARED: Record<string, string> = {
+  up: '↑',
+  down: '↓',
+  right: '→',
+  left: '←'
+}
+
+const MAC: Record<string, string> = {
+  mod: '⌘',
+  shift: '⇧',
+  ctrl: '⌃',
+  control: '⌃',
+  alt: '⌥',
+  opt: '⌥',
+  option: '⌥'
+}
+
+const PC: Record<string, string> = {
+  mod: 'Ctrl',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  shift: 'Shift',
+  alt: 'Alt',
+  opt: 'Alt',
+  option: 'Alt'
+}
+
+export function modifier(hotkey: string, mac: boolean = IS_MAC): string {
+  if (!hotkey) return ''
+  const tokens = hotkey
+    .split('+')
+    .map((token) => formatToken(token, mac))
+    .filter(Boolean)
+  return tokens.join(mac ? '' : '+')
+}
+
+function formatToken(token: string, mac: boolean): string {
+  const t = token.toLowerCase()
+  const mapped = (mac ? MAC : PC)[t] ?? SHARED[t]
+  if (mapped) return mapped
+  return token.length === 1 ? token.toUpperCase() : token
 }

--- a/tests/modifier.test.ts
+++ b/tests/modifier.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { modifier, isMac } from '@/utils/modifier'
+
+describe('modifier (textbit hotkey legend formatter)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('on Mac', () => {
+    it('renders modifier glyphs joined without a separator', () => {
+      expect(modifier('mod+option+1', true)).toBe('⌘⌥1')
+    })
+
+    it('maps mod, shift, ctrl/control, alt/option to glyphs', () => {
+      expect(modifier('mod+b', true)).toBe('⌘B')
+      expect(modifier('mod+i', true)).toBe('⌘I')
+      expect(modifier('mod+u', true)).toBe('⌘U')
+      expect(modifier('shift+ctrl+a', true)).toBe('⇧⌃A')
+      expect(modifier('mod+alt+1', true)).toBe('⌘⌥1')
+      expect(modifier('mod+option+1', true)).toBe('⌘⌥1')
+      expect(modifier('mod+control+1', true)).toBe('⌘⌃1')
+      expect(modifier('mod+opt+1', true)).toBe('⌘⌥1')
+    })
+
+    it('maps arrow keys to arrow glyphs', () => {
+      expect(modifier('mod+option+up', true)).toBe('⌘⌥↑')
+      expect(modifier('mod+option+down', true)).toBe('⌘⌥↓')
+      expect(modifier('mod+option+left', true)).toBe('⌘⌥←')
+      expect(modifier('mod+option+right', true)).toBe('⌘⌥→')
+    })
+  })
+
+  describe('on non-Mac (Windows / Linux / Chromebook)', () => {
+    it('renders modifier names joined by plus signs', () => {
+      expect(modifier('mod+option+1', false)).toBe('Ctrl+Alt+1')
+    })
+
+    it('maps mod and ctrl/control to "Ctrl"', () => {
+      expect(modifier('mod+b', false)).toBe('Ctrl+B')
+      expect(modifier('ctrl+b', false)).toBe('Ctrl+B')
+      expect(modifier('control+b', false)).toBe('Ctrl+B')
+    })
+
+    it('maps option/alt to "Alt"', () => {
+      expect(modifier('mod+option+1', false)).toBe('Ctrl+Alt+1')
+      expect(modifier('mod+alt+1', false)).toBe('Ctrl+Alt+1')
+      expect(modifier('mod+opt+1', false)).toBe('Ctrl+Alt+1')
+    })
+
+    it('uppercases single-letter keys', () => {
+      expect(modifier('mod+i', false)).toBe('Ctrl+I')
+      expect(modifier('mod+u', false)).toBe('Ctrl+U')
+    })
+
+    it('passes digits through unchanged', () => {
+      expect(modifier('mod+option+0', false)).toBe('Ctrl+Alt+0')
+      expect(modifier('mod+option+3', false)).toBe('Ctrl+Alt+3')
+    })
+
+    it('maps arrow keys to arrow glyphs even on PC', () => {
+      expect(modifier('mod+option+up', false)).toBe('Ctrl+Alt+↑')
+      expect(modifier('mod+option+down', false)).toBe('Ctrl+Alt+↓')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty string for empty input', () => {
+      expect(modifier('', false)).toBe('')
+      expect(modifier('', true)).toBe('')
+    })
+
+    it('handles a single key without modifiers', () => {
+      expect(modifier('b', false)).toBe('B')
+      expect(modifier('b', true)).toBe('B')
+    })
+
+    it('is case-insensitive on input tokens', () => {
+      expect(modifier('MOD+OPTION+1', false)).toBe('Ctrl+Alt+1')
+      expect(modifier('MOD+OPTION+1', true)).toBe('⌘⌥1')
+    })
+  })
+})
+
+describe('isMac', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('prefers userAgentData.platform when present', () => {
+    vi.stubGlobal('navigator', {
+      userAgentData: { platform: 'macOS' },
+      platform: 'Win32',
+      userAgent: 'Mozilla/5.0 (irrelevant)'
+    })
+    expect(isMac()).toBe(true)
+  })
+
+  it('returns false when userAgentData reports Windows even if userAgent contains "Mac"', () => {
+    vi.stubGlobal('navigator', {
+      userAgentData: { platform: 'Windows' },
+      platform: 'MacIntel',
+      userAgent: 'Macintosh; misleading'
+    })
+    expect(isMac()).toBe(false)
+  })
+
+  it('falls back to navigator.platform', () => {
+    vi.stubGlobal('navigator', { platform: 'MacIntel', userAgent: 'irrelevant' })
+    expect(isMac()).toBe(true)
+    vi.stubGlobal('navigator', { platform: 'Win32', userAgent: 'irrelevant' })
+    expect(isMac()).toBe(false)
+    vi.stubGlobal('navigator', { platform: 'Linux x86_64', userAgent: 'irrelevant' })
+    expect(isMac()).toBe(false)
+  })
+
+  it('falls back to userAgent', () => {
+    vi.stubGlobal('navigator', {
+      platform: '',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+    })
+    expect(isMac()).toBe(true)
+    vi.stubGlobal('navigator', {
+      platform: '',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    })
+    expect(isMac()).toBe(false)
+  })
+
+  it('returns false when navigator is undefined', () => {
+    vi.stubGlobal('navigator', undefined)
+    expect(isMac()).toBe(false)
+  })
+})


### PR DESCRIPTION
Menu.Hotkey rendered Mac glyphs (⌘ ⌥ ⌃ ⇧) for every platform, leaving Windows, Linux and Chromebook editors with opaque labels that did not match the keys they had to press.

modifier() now consults an isMac() check that prefers navigator.userAgentData.platform, falls back to navigator.platform, and finally to navigator.userAgent. The result is captured once at module load as IS_MAC and used as modifier()'s default so the per-render menu path doesn't re-probe the navigator on every action. Mac users keep the Unicode glyphs; everyone else now sees spelled-out modifier names joined by "+", e.g. "Ctrl+Alt+1", "Ctrl+B", "Ctrl+Alt+Up".

isMac is also exported from the library entry so consumers can stop reinventing the detection.

Refs ELELOG-624