### PR TITLE
Feature/elelog 704 when user clicks in text the caret looses focus

### DIFF
--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -97,6 +97,14 @@ export function TextbitEditable(props: TextbitEditableProps) {
 
       setSpellingLookupTable(newLookupTable)
 
+      // The DOM Selection is a single document-wide object, so deselecting
+      // here would clear whatever caret another editor on the page currently
+      // owns. Skip the repaint hack unless this editor is the focused one;
+      // decorations will repaint naturally when focus returns here.
+      if (!ReactEditor.isFocused(editor)) {
+        return
+      }
+
       // HACK: Deselect and select the editor to ensure the dom selection is correctly updated.
       // FIXME: When https://github.com/ianstormtaylor/slate/issues/5987
       const selection = editor.selection

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -38,7 +38,6 @@ export function TextbitEditable(props: TextbitEditableProps) {
   const { placeholders, placeholder, readOnly, dir, collaborative, verbose } = useTextbit()
   const { components, actions } = usePluginRegistry()
   const isFocused = useFocused()
-  const [decorationsKey, setDecorationsKey] = useState(0)
   const handleContextMenu = useContextMenu()
   const [spellingLookupTable, setSpellingLookupTable] = useState<SpellcheckLookupTable>(new Map())
   const [adjacentBlock, setAdjacentBlock] = useState<AdjacentBlockState | null>(null)
@@ -58,25 +57,27 @@ export function TextbitEditable(props: TextbitEditableProps) {
     }
   }, [])
 
-  // Focus the actual editable DOM node on mount
-  const handleFocus = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
-    queueMicrotask(() => {
-      if (!editor.selection && decorationsKey === 0) {
-        if (autoFocus === 'end') {
-          Transforms.select(editor, Editor.end(editor, []))
-        } else {
-          Transforms.select(editor, Editor.start(editor, []))
-        }
-        setDecorationsKey(prev => prev + 1)
-      }
-    })
-
-    if (onFocus) {
-      onFocus(e)
+  // Place the initial caret when autoFocus is set. slate-react's <Editable
+  // autoFocus> focuses the DOM node but does not set editor.selection, so we
+  // do that here. Runs on mount only — user clicks must not be intercepted.
+  useEffect(() => {
+    if (!autoFocus) {
+      return
     }
-  }, [autoFocus, decorationsKey, editor, onFocus])
 
-  // Increment decorationkey to ensure re-render when spellcheck completes
+    queueMicrotask(() => {
+      if (editor.selection) {
+        return
+      }
+
+      Transforms.select(
+        editor,
+        autoFocus === 'end' ? Editor.end(editor, []) : Editor.start(editor, [])
+      )
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   useEffect(() => {
     if (typeof editor.onSpellcheckComplete !== 'function') {
       return
@@ -100,7 +101,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
         }
       }, 10)
     })
-  }, [editor, isFocused, setDecorationsKey])
+  }, [editor, isFocused])
 
   // Render element callback
   const renderElement = useCallback((props: RenderElementProps) => {
@@ -263,7 +264,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
                 readOnly={readOnly}
                 renderElement={renderElement}
                 renderLeaf={renderLeaf}
-                onFocus={handleFocus}
+                onFocus={onFocus}
                 onBlur={handleBlur}
                 onKeyDown={onKeyDown}
                 onPaste={onPaste}

--- a/lib/components/TextbitEditable/TextbitEditable.tsx
+++ b/lib/components/TextbitEditable/TextbitEditable.tsx
@@ -57,16 +57,21 @@ export function TextbitEditable(props: TextbitEditableProps) {
     }
   }, [])
 
-  // Place the initial caret when autoFocus is set. slate-react's <Editable
-  // autoFocus> focuses the DOM node but does not set editor.selection, so we
-  // do that here. Runs on mount only — user clicks must not be intercepted.
-  useEffect(() => {
-    if (!autoFocus) {
-      return
-    }
+  // Tracks whether a mousedown happened immediately before the focus event.
+  // A click flow is mousedown -> focus; Tab and programmatic focus are not
+  // preceded by a mousedown. This lets us tell them apart inside handleFocus.
+  const focusFromMouseRef = useRef(false)
+
+  // Place an initial caret when the editor gains focus via Tab, autoFocus, or
+  // programmatic focus without a prior selection. Clicks are left alone: the
+  // browser places the DOM caret on mousedown, and slate-react's
+  // selectionchange handler syncs that to editor.selection shortly after.
+  const handleFocus = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    const fromMouse = focusFromMouseRef.current
+    focusFromMouseRef.current = false
 
     queueMicrotask(() => {
-      if (editor.selection) {
+      if (fromMouse || editor.selection) {
         return
       }
 
@@ -75,8 +80,9 @@ export function TextbitEditable(props: TextbitEditableProps) {
         autoFocus === 'end' ? Editor.end(editor, []) : Editor.start(editor, [])
       )
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+
+    onFocus?.(e)
+  }, [editor, autoFocus, onFocus])
 
   useEffect(() => {
     if (typeof editor.onSpellcheckComplete !== 'function') {
@@ -192,6 +198,9 @@ export function TextbitEditable(props: TextbitEditableProps) {
    * resolve a click position outside any editable text.
    */
   const onMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // Signal to handleFocus that the upcoming focus event came from a click.
+    focusFromMouseRef.current = true
+
     const clickX = event.clientX
     const clickY = event.clientY
 
@@ -264,7 +273,7 @@ export function TextbitEditable(props: TextbitEditableProps) {
                 readOnly={readOnly}
                 renderElement={renderElement}
                 renderLeaf={renderLeaf}
-                onFocus={onFocus}
+                onFocus={handleFocus}
                 onBlur={handleBlur}
                 onKeyDown={onKeyDown}
                 onPaste={onPaste}


### PR DESCRIPTION
This PR should fix:
When the user clicks somewhere in a text field the caret often jumps to the start because of bad handling of focus events.
When the user types quickly, then jumps to next editor and types quickly the user looses focus and keystrokes are missed.