### PR TITLE
fix: only treat editor as collaborative when awareness is non-null

### DIFF
--- a/lib/components/SlateContainer.tsx
+++ b/lib/components/SlateContainer.tsx
@@ -200,7 +200,7 @@ function isSlateContainerYjsProps(
 function isSlateContainerCollaborationProps(
   props: SlateContainerProps
 ): props is SlateContainerCollaborationProps {
-  return props.value instanceof Y.XmlText && 'awareness' in props
+  return props.value instanceof Y.XmlText && 'awareness' in props && props.awareness != null
 }
 
 function isSlateContainerStringProps(

--- a/lib/components/TextbitRoot.tsx
+++ b/lib/components/TextbitRoot.tsx
@@ -115,5 +115,5 @@ export function TextbitRoot(props: TextbitRootProps) {
 function isTextbitRootCollaborationProps(
   props: TextbitRootProps
 ): props is TextbitRootCollaborationProps {
-  return props.value instanceof Y.XmlText && 'awareness' in props
+  return props.value instanceof Y.XmlText && 'awareness' in props && props.awareness != null
 }

--- a/tests/CollaborativeDetection.test.tsx
+++ b/tests/CollaborativeDetection.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect } from 'vitest'
+import * as Y from 'yjs'
+import { slateNodesToInsertDelta } from '@slate-yjs/core'
+import { TextbitRoot } from '../lib/components/TextbitRoot'
+import { TextbitEditable } from '../lib/components/TextbitEditable/TextbitEditable'
+import { basicEditorContent } from './_fixtures'
+
+function makeSharedType(): Y.XmlText {
+  const doc = new Y.Doc()
+  const sharedType = doc.get('content', Y.XmlText) as Y.XmlText
+  sharedType.applyDelta(slateNodesToInsertDelta(basicEditorContent))
+  return sharedType
+}
+
+describe('Textbit collaborative detection', () => {
+  test('a Yjs value with null awareness renders as a plain editor (no remote-cursor overlay, no throw)', () => {
+    const sharedType = makeSharedType()
+
+    const { container } = render(
+      <TextbitRoot value={sharedType} awareness={null}>
+        <TextbitEditable />
+      </TextbitRoot>
+    )
+
+    expect(container.querySelector('.textbit-y-overlay')).toBeNull()
+    expect(screen.getByText('This is title')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
A Y.XmlText value with the `awareness` prop key present but null/undefined (e.g. a local-only draft with no peers) was flagged collaborative, which mounts the remote-cursor overlay. withCursors then stored a falsy awareness, so CursorEditor.isCursorEditor returned false and useRemoteCursorOverlayPositions threw "Cannot use useSyncExternalStore outside the context of a RemoteCursorEditor".

Require a non-null awareness in both isTextbitRootCollaborationProps and isSlateContainerCollaborationProps so the collaborative flag and the withCursors attachment agree. A peerless Yjs value now renders as a plain Yjs editor with no cursor overlay.

Adds a regression test covering both the null-awareness and real-awareness paths.